### PR TITLE
Fix DeepResearch mode validation error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="valyu",
-    version="2.4.0",
+    version="2.4.1",
     author="Valyu",
     author_email="contact@valyu.ai",
     maintainer="Harvey Yorke",

--- a/valyu/types/deepresearch.py
+++ b/valyu/types/deepresearch.py
@@ -7,7 +7,8 @@ class DeepResearchMode(str, Enum):
     """Research mode options."""
 
     FAST = "fast"
-    LITE = "lite"
+    STANDARD = "standard"
+    LITE = "lite"  # Deprecated: use STANDARD instead (kept for backward compatibility)
     HEAVY = "heavy"
 
 


### PR DESCRIPTION
## Summary
Fixed validation error where deepresearch.create() was returning None for deepresearch_id and status.

## Changes
- Added "standard" as a valid DeepResearchMode value
- The backend now returns "standard" instead of "lite", causing Pydantic validation to fail
- Kept "lite" for backward compatibility with deprecation note
- Version bump: 2.4.0 -> 2.4.1

## Issue
The API was returning `model="standard"` in responses, but the SDK only accepted "fast", "lite", or "heavy", causing all responses to fail validation and return None values.