### PR TITLE
Increase default wait time to 2 hours

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="valyu",
-    version="2.4.1",
+    version="2.4.2",
     author="Valyu",
     author_email="contact@valyu.ai",
     maintainer="Harvey Yorke",

--- a/valyu/deepresearch_client.py
+++ b/valyu/deepresearch_client.py
@@ -176,7 +176,7 @@ class DeepResearchClient:
         self,
         task_id: str,
         poll_interval: int = 5,
-        max_wait_time: int = 3600,
+        max_wait_time: int = 7200,
         on_progress: Optional[Callable[[DeepResearchStatusResponse], None]] = None,
     ) -> DeepResearchStatusResponse:
         """
@@ -185,7 +185,7 @@ class DeepResearchClient:
         Args:
             task_id: Task ID to wait for
             poll_interval: Seconds between polls (default: 5)
-            max_wait_time: Maximum wait time in seconds (default: 3600)
+            max_wait_time: Maximum wait time in seconds (default: 7200)
             on_progress: Callback for progress updates
 
         Returns:


### PR DESCRIPTION
## Summary
Increased default max_wait_time from 1 hour to 2 hours for deepresearch.wait() to better accommodate longer research tasks.

## Changes
- Updated max_wait_time default: 3600 seconds → 7200 seconds (2 hours)
- Updated docstring to reflect new default
- Version bump: 2.4.1 → 2.4.2