### PR TITLE
Add max deep research mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="valyu",
-    version="2.5.4",
+    version="2.5.5",
     author="Valyu",
     author_email="contact@valyu.ai",
     maintainer="Harvey Yorke",

--- a/valyu/batch_client.py
+++ b/valyu/batch_client.py
@@ -32,8 +32,8 @@ class BatchClient:
     def create(
         self,
         name: Optional[str] = None,
-        mode: Optional[Literal["lite", "standard", "heavy", "fast"]] = None,
-        model: Optional[Literal["lite", "standard", "heavy", "fast"]] = None,
+        mode: Optional[Literal["lite", "standard", "heavy", "fast", "max"]] = None,
+        model: Optional[Literal["lite", "standard", "heavy", "fast", "max"]] = None,
         output_formats: Optional[
             List[Union[Literal["markdown", "pdf", "toon"], Dict[str, Any]]]
         ] = None,
@@ -414,8 +414,8 @@ class BatchClient:
         self,
         tasks: List[Union[BatchTaskInput, Dict[str, Any]]],
         name: Optional[str] = None,
-        mode: Optional[Literal["lite", "standard", "heavy", "fast"]] = None,
-        model: Optional[Literal["lite", "standard", "heavy", "fast"]] = None,
+        mode: Optional[Literal["lite", "standard", "heavy", "fast", "max"]] = None,
+        model: Optional[Literal["lite", "standard", "heavy", "fast", "max"]] = None,
         output_formats: Optional[
             List[Union[Literal["markdown", "pdf", "toon"], Dict[str, Any]]]
         ] = None,

--- a/valyu/deepresearch_client.py
+++ b/valyu/deepresearch_client.py
@@ -58,10 +58,10 @@ class DeepResearchClient:
         Args:
             query: Research query or task description (preferred)
             input: Research query or task description (deprecated, use query instead)
-            mode: Research mode - "standard" (default, $0.50 per task), "heavy" ($1.50 per task),
-                  or "fast" ($0.10 per task, preferred). Preferred over model parameter.
+            mode: Research mode - "fast", "standard" (default), "heavy", or "max".
+                  Preferred over model parameter.
             model: Research mode (backward compatibility - use 'mode' instead) - "standard" (default),
-                  "heavy", "fast", or "lite" (deprecated, maps to "standard")
+                  "heavy", "fast", "max", or "lite" (deprecated, maps to "standard")
             output_formats: Output formats - ["markdown"], ["markdown", "pdf"], or a JSON schema object.
                            When using a JSON schema, the output will be structured JSON instead of markdown.
                            Cannot mix JSON schema with markdown/pdf - use one or the other.

--- a/valyu/types/deepresearch.py
+++ b/valyu/types/deepresearch.py
@@ -10,6 +10,7 @@ class DeepResearchMode(str, Enum):
     STANDARD = "standard"
     LITE = "lite"  # Deprecated: use STANDARD instead (kept for backward compatibility)
     HEAVY = "heavy"
+    MAX = "max"
 
 
 class DeepResearchStatus(str, Enum):


### PR DESCRIPTION
## Summary
- Add `MAX` variant to `DeepResearchMode` enum
- Update `Literal` types in batch client to include `max`
- Update docstrings to reflect available modes
- Bump version to 2.5.5