### PR TITLE
Add instructions parameter to search API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="valyu",
-    version="2.9.1",
+    version="2.9.2",
     author="Valyu",
     author_email="contact@valyu.ai",
     maintainer="Harvey Yorke",

--- a/valyu/api.py
+++ b/valyu/api.py
@@ -90,6 +90,7 @@ class Valyu:
         fast_mode: bool = False,
         url_only: bool = False,
         source_biases: Optional[Dict[str, int]] = None,
+        instructions: Optional[str] = None,
     ) -> Optional[SearchResponse]:
         """
         Query the Valyu DeepSearch API to give your AI relevant context.
@@ -122,6 +123,10 @@ class Valyu:
                 Keys are domains (e.g., "nasa.gov") or URL paths (e.g., "nytimes.com/science").
                 Values are integers from -5 (strong demotion) to +5 (strong boost).
                 Unlike included/excluded_sources, biases adjust ranking without hard filtering.
+            instructions (Optional[str]): Natural language instructions to help rank results by relevance
+                to user intent. Acts as a system prompt for the search — e.g.
+                "Focus on oncology clinical trials from 2023 onwards". Max 500 characters.
+                Ignored when fast_mode=True.
 
         Returns:
             Optional[SearchResponse]: The search response.
@@ -209,6 +214,9 @@ class Valyu:
 
             if source_biases is not None:
                 payload["source_biases"] = source_biases
+
+            if instructions is not None:
+                payload["instructions"] = instructions
 
             response = requests.post(
                 f"{self.base_url}/deepsearch", json=payload, headers=self.headers


### PR DESCRIPTION
## Summary
- Add `instructions` parameter to `search()` method — natural language instructions to help rank results by relevance to user intent
- Max 500 characters, ignored when `fast_mode=True`
- Falls back to `category` if not provided (API-side behavior)
- Bump version 2.9.1 → 2.9.2

## Test plan
- [ ] Verify `instructions` is passed through to the API payload
- [ ] Verify omitting `instructions` does not change existing behavior
- [ ] Test with `fast_mode=True` to confirm it's ignored server-side