### PR TITLE
Session reuse

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="valyu",
-    version="2.9.3",
+    version="2.9.4",
     author="Valyu",
     author_email="contact@valyu.ai",
     maintainer="Harvey Yorke",

--- a/valyu/__init__.py
+++ b/valyu/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.9.3"
+__version__ = "2.9.4"
 
 from .types.response import SearchResponse
 from .types.contents import (

--- a/valyu/api.py
+++ b/valyu/api.py
@@ -66,6 +66,10 @@ class Valyu:
             "X-Valyu-SDK-Version": __version__,
         }
 
+        # Persistent session for TCP+TLS connection reuse
+        self._session = requests.Session()
+        self._session.headers.update(self.headers)
+
         # Initialize DeepResearch client
         self.deepresearch = DeepResearchClient(self)
 
@@ -218,8 +222,8 @@ class Valyu:
             if instructions is not None:
                 payload["instructions"] = instructions
 
-            response = requests.post(
-                f"{self.base_url}/search", json=payload, headers=self.headers
+            response = self._session.post(
+                f"{self.base_url}/search", json=payload
             )
 
             data = response.json()
@@ -366,8 +370,8 @@ class Valyu:
             if webhook_url:
                 payload["webhook_url"] = webhook_url
 
-            response = requests.post(
-                f"{self.base_url}/contents", json=payload, headers=self.headers
+            response = self._session.post(
+                f"{self.base_url}/contents", json=payload
             )
 
             data = response.json()
@@ -419,9 +423,8 @@ class Valyu:
         Returns:
             ContentsJobStatus with current status and results when terminal.
         """
-        response = requests.get(
+        response = self._session.get(
             f"{self.base_url}/contents/jobs/{job_id}",
-            headers=self.headers,
         )
         data = response.json()
 
@@ -651,11 +654,10 @@ class Valyu:
         """Fetch the complete answer (non-streaming mode)."""
         try:
             # Use streaming internally but collect into final response
-            headers = {**self.headers, "Accept": "text/event-stream"}
-            response = requests.post(
+            response = self._session.post(
                 f"{self.base_url}/answer",
                 json=payload,
-                headers=headers,
+                headers={"Accept": "text/event-stream"},
                 stream=True,
             )
 
@@ -771,11 +773,10 @@ class Valyu:
     def _stream_answer(self, payload: Dict[str, Any]) -> AnswerStreamGenerator:
         """Stream the answer response as chunks."""
         try:
-            headers = {**self.headers, "Accept": "text/event-stream"}
-            response = requests.post(
+            response = self._session.post(
                 f"{self.base_url}/answer",
                 json=payload,
-                headers=headers,
+                headers={"Accept": "text/event-stream"},
                 stream=True,
             )
 
@@ -901,10 +902,9 @@ class Valyu:
             if category is not None:
                 params["category"] = category
 
-            response = requests.get(
+            response = self._session.get(
                 f"{self.base_url}/datasources",
                 params=params if params else None,
-                headers=self.headers,
             )
 
             data = response.json()
@@ -944,9 +944,8 @@ class Valyu:
                 names and dataset counts.
         """
         try:
-            response = requests.get(
+            response = self._session.get(
                 f"{self.base_url}/datasources/categories",
-                headers=self.headers,
             )
 
             data = response.json()

--- a/valyu/batch_client.py
+++ b/valyu/batch_client.py
@@ -3,7 +3,6 @@ Batch Client for Valyu SDK
 """
 
 import time
-import requests
 from typing import Optional, List, Literal, Union, Dict, Any, Callable
 from valyu.types.deepresearch import (
     BatchStatus,
@@ -26,6 +25,7 @@ class BatchClient:
         self._parent = parent
         self._base_url = parent.base_url
         self._headers = parent.headers
+        self._session = parent._session
 
     def create(
         self,
@@ -101,10 +101,9 @@ class BatchClient:
             if metadata:
                 payload["metadata"] = metadata
 
-            response = requests.post(
+            response = self._session.post(
                 f"{self._base_url}/deepresearch/batches",
                 json=payload,
-                headers=self._headers,
             )
 
             data = response.json()
@@ -153,10 +152,9 @@ class BatchClient:
 
             payload = {"tasks": task_dicts}
 
-            response = requests.post(
+            response = self._session.post(
                 f"{self._base_url}/deepresearch/batches/{batch_id}/tasks",
                 json=payload,
-                headers=self._headers,
             )
 
             data = response.json()
@@ -186,9 +184,8 @@ class BatchClient:
             BatchStatusResponse with current batch status and task counts
         """
         try:
-            response = requests.get(
+            response = self._session.get(
                 f"{self._base_url}/deepresearch/batches/{batch_id}",
-                headers=self._headers,
             )
 
             data = response.json()
@@ -248,9 +245,8 @@ class BatchClient:
             if include_output is not None:
                 params["include_output"] = str(include_output).lower()
 
-            response = requests.get(
+            response = self._session.get(
                 f"{self._base_url}/deepresearch/batches/{batch_id}/tasks",
-                headers=self._headers,
                 params=params if params else None,
             )
 
@@ -281,10 +277,9 @@ class BatchClient:
             BatchCancelResponse
         """
         try:
-            response = requests.post(
+            response = self._session.post(
                 f"{self._base_url}/deepresearch/batches/{batch_id}/cancel",
                 json={},
-                headers=self._headers,
             )
 
             data = response.json()
@@ -322,10 +317,9 @@ class BatchClient:
             if limit is not None:
                 params["limit"] = limit
 
-            response = requests.get(
+            response = self._session.get(
                 f"{self._base_url}/deepresearch/batches",
                 params=params if params else None,
-                headers=self._headers,
             )
 
             data = response.json()

--- a/valyu/deepresearch_client.py
+++ b/valyu/deepresearch_client.py
@@ -35,6 +35,7 @@ class DeepResearchClient:
         self._parent = parent
         self._base_url = parent.base_url
         self._headers = parent.headers
+        self._session = parent._session
 
     def create(
         self,
@@ -239,10 +240,9 @@ class DeepResearchClient:
                 else:
                     payload["hitl"] = hitl
 
-            response = requests.post(
+            response = self._session.post(
                 f"{self._base_url}/deepresearch/tasks",
                 json=payload,
-                headers=self._headers,
             )
 
             data = response.json()
@@ -273,9 +273,8 @@ class DeepResearchClient:
             DeepResearchStatusResponse with current status
         """
         try:
-            response = requests.get(
+            response = self._session.get(
                 f"{self._base_url}/deepresearch/tasks/{task_id}/status",
-                headers=self._headers,
             )
 
             data = response.json()
@@ -446,10 +445,9 @@ class DeepResearchClient:
             if limit is not None:
                 params["limit"] = limit
 
-            response = requests.get(
+            response = self._session.get(
                 f"{self._base_url}/deepresearch/list",
                 params=params,
-                headers=self._headers,
             )
 
             data = response.json()
@@ -486,10 +484,9 @@ class DeepResearchClient:
                     error="instruction is required and cannot be empty",
                 )
 
-            response = requests.post(
+            response = self._session.post(
                 f"{self._base_url}/deepresearch/tasks/{task_id}/update",
                 json={"instruction": instruction},
-                headers=self._headers,
             )
 
             data = response.json()
@@ -537,10 +534,9 @@ class DeepResearchClient:
                 "response": response,
             }
 
-            resp = requests.post(
+            resp = self._session.post(
                 f"{self._base_url}/deepresearch/tasks/{task_id}/respond",
                 json=payload,
-                headers=self._headers,
             )
 
             data = resp.json()
@@ -662,10 +658,9 @@ class DeepResearchClient:
             DeepResearchCancelResponse
         """
         try:
-            response = requests.post(
+            response = self._session.post(
                 f"{self._base_url}/deepresearch/tasks/{task_id}/cancel",
                 json={},
-                headers=self._headers,
             )
 
             data = response.json()
@@ -696,9 +691,8 @@ class DeepResearchClient:
             DeepResearchDeleteResponse
         """
         try:
-            response = requests.delete(
+            response = self._session.delete(
                 f"{self._base_url}/deepresearch/tasks/{task_id}/delete",
-                headers=self._headers,
             )
 
             data = response.json()
@@ -739,22 +733,17 @@ class DeepResearchClient:
         try:
             url = f"{self._base_url}/deepresearch/tasks/{task_id}/assets/{asset_id}"
 
-            # Build headers - use API key if no token provided
-            # Always include SDK attribution headers
-            sdk_headers = {
-                k: v
-                for k, v in self._headers.items()
-                if k.startswith("X-Valyu-") or k == "User-Agent"
-            }
             if token:
-                # Token is passed as query parameter, not header
+                # Token is passed as query parameter; strip auth headers for this request
+                sdk_headers = {
+                    k: v
+                    for k, v in self._headers.items()
+                    if k.startswith("X-Valyu-") or k == "User-Agent"
+                }
                 url += f"?token={token}"
-                headers = sdk_headers
+                response = self._session.get(url, headers=sdk_headers)
             else:
-                # Use API key from headers
-                headers = self._headers.copy()
-
-            response = requests.get(url, headers=headers)
+                response = self._session.get(url)
 
             if not response.ok:
                 error_data = (
@@ -789,10 +778,9 @@ class DeepResearchClient:
             DeepResearchTogglePublicResponse
         """
         try:
-            response = requests.post(
+            response = self._session.post(
                 f"{self._base_url}/deepresearch/tasks/{task_id}/public",
                 json={"public": is_public},
-                headers=self._headers,
             )
 
             data = response.json()


### PR DESCRIPTION
## Summary

- Replace per-call `requests.post`/`requests.get` with a persistent `requests.Session` created once in `__init__`
- Common headers (x-api-key, Content-Type, User-Agent, SDK attribution) are set on the session and reused across all HTTP calls in `api.py`, `batch_client.py`, and `deepresearch_client.py`
- This reuses TCP+TLS connections across calls, avoiding the overhead of a fresh connection and TLS handshake on every request
- Bump version to 2.9.4