### PR TITLE
Remove s3_key field from DeliverableResult to fix information disclosure

### DIFF
--- a/valyu/types/deepresearch.py
+++ b/valyu/types/deepresearch.py
@@ -91,7 +91,6 @@ class DeliverableResult(BaseModel):
     url: str = Field(
         ..., description="Token-signed authenticated URL to download the file"
     )
-    s3_key: str = Field(..., description="S3 storage key")
     row_count: Optional[int] = Field(None, description="Number of rows (for CSV/XLSX)")
     column_count: Optional[int] = Field(
         None, description="Number of columns (for CSV/XLSX)"
@@ -145,7 +144,8 @@ class SearchConfig(BaseModel):
     )
     category: Optional[str] = Field(None, description="Category filter for results")
     country_code: Optional[str] = Field(
-        None, description="ISO country code for location-filtered searches (e.g., 'US', 'GB')"
+        None,
+        description="ISO country code for location-filtered searches (e.g., 'US', 'GB')",
     )
     source_biases: Optional[Dict[str, int]] = Field(
         None,
@@ -177,8 +177,12 @@ class ChartDataSeries(BaseModel):
 class DeepResearchTools(BaseModel):
     """Tools configuration for deep research tasks."""
 
-    code_execution: Optional[bool] = Field(False, description="Enable code execution in sandboxed environment")
-    screenshots: Optional[bool] = Field(False, description="Enable visual screenshot capture of web pages")
+    code_execution: Optional[bool] = Field(
+        False, description="Enable code execution in sandboxed environment"
+    )
+    screenshots: Optional[bool] = Field(
+        False, description="Enable visual screenshot capture of web pages"
+    )
 
 
 class ImageMetadata(BaseModel):
@@ -231,9 +235,16 @@ class DeepResearchCostBreakdown(BaseModel):
     """Itemized cost breakdown for a deep research task."""
 
     task: float = Field(..., description="Base task price for the selected mode")
-    screenshots: Optional[float] = Field(None, description="Screenshot surcharges ($0.05 per URL captured)")
-    code_execution: Optional[float] = Field(None, description="Code execution surcharges ($0.10 per execution)")
-    deliverables: Optional[float] = Field(None, description="Deliverable surcharges ($0.10 per deliverable after the first)")
+    screenshots: Optional[float] = Field(
+        None, description="Screenshot surcharges ($0.05 per URL captured)"
+    )
+    code_execution: Optional[float] = Field(
+        None, description="Code execution surcharges ($0.10 per execution)"
+    )
+    deliverables: Optional[float] = Field(
+        None,
+        description="Deliverable surcharges ($0.10 per deliverable after the first)",
+    )
 
 
 class HitlConfig(BaseModel):
@@ -253,7 +264,8 @@ class HitlConfig(BaseModel):
         None, description="Pause after research for user to filter sources by domain"
     )
     outline_review: Optional[bool] = Field(
-        None, description="Pause after source review for user to review the report outline"
+        None,
+        description="Pause after source review for user to review the report outline",
     )
 
 
@@ -269,10 +281,14 @@ class InteractionType(str, Enum):
 class Interaction(BaseModel):
     """HITL interaction payload returned when a task is awaiting input."""
 
-    interaction_id: str = Field(..., description="Unique ID for this interaction (use when responding)")
+    interaction_id: str = Field(
+        ..., description="Unique ID for this interaction (use when responding)"
+    )
     type: InteractionType = Field(..., description="Type of checkpoint")
     data: Dict[str, Any] = Field(..., description="Checkpoint-specific data")
-    created_at: int = Field(..., description="Unix timestamp (ms) when checkpoint fired")
+    created_at: int = Field(
+        ..., description="Unix timestamp (ms) when checkpoint fired"
+    )
     timeout_ms: int = Field(..., description="Timeout duration in milliseconds")
     expected_response: Optional[Dict[str, Any]] = Field(
         None, description="Schema hint for the expected response shape"
@@ -285,9 +301,15 @@ class InteractionHistoryEntry(BaseModel):
     interaction_id: str
     type: InteractionType
     created_at: int = Field(..., description="When the checkpoint fired (ms)")
-    responded_at: Optional[int] = Field(None, description="When the user responded (ms)")
-    auto_continued: bool = Field(..., description="True if timed out, false if user responded")
-    response: Optional[Dict[str, Any]] = Field(None, description="The user's response (absent if timed out)")
+    responded_at: Optional[int] = Field(
+        None, description="When the user responded (ms)"
+    )
+    auto_continued: bool = Field(
+        ..., description="True if timed out, false if user responded"
+    )
+    response: Optional[Dict[str, Any]] = Field(
+        None, description="The user's response (absent if timed out)"
+    )
 
 
 class DeepResearchCreateResponse(BaseModel):
@@ -332,15 +354,27 @@ class DeepResearchStatusResponse(BaseModel):
     deliverables: Optional[List[DeliverableResult]] = None
     sources: Optional[List[DeepResearchSource]] = None
     cost: Optional[float] = None
-    cost_breakdown: Optional[DeepResearchCostBreakdown] = Field(None, description="Itemized cost breakdown (task, screenshots, code_execution, deliverables)")
-    tools: Optional[DeepResearchTools] = Field(None, description="Resolved tools configuration")
+    cost_breakdown: Optional[DeepResearchCostBreakdown] = Field(
+        None,
+        description="Itemized cost breakdown (task, screenshots, code_execution, deliverables)",
+    )
+    tools: Optional[DeepResearchTools] = Field(
+        None, description="Resolved tools configuration"
+    )
     batch_id: Optional[str] = None
     batch_task_id: Optional[str] = None
 
     # HITL fields
-    hitl_config: Optional[Dict[str, Any]] = Field(None, description="HITL configuration (mirrors request hitl param)")
-    interaction: Optional[Interaction] = Field(None, description="Current HITL checkpoint (present when awaiting_input or paused)")
-    hitl_history: Optional[List[InteractionHistoryEntry]] = Field(None, description="History of completed HITL checkpoints")
+    hitl_config: Optional[Dict[str, Any]] = Field(
+        None, description="HITL configuration (mirrors request hitl param)"
+    )
+    interaction: Optional[Interaction] = Field(
+        None,
+        description="Current HITL checkpoint (present when awaiting_input or paused)",
+    )
+    hitl_history: Optional[List[InteractionHistoryEntry]] = Field(
+        None, description="History of completed HITL checkpoints"
+    )
 
     error: Optional[str] = None
 
@@ -456,7 +490,8 @@ class BatchTaskInput(BaseModel):
         description="Research query or task description (deprecated, use query instead)",
     )
     strategy: Optional[str] = Field(
-        None, description="Natural language strategy (deprecated, use research_strategy)"
+        None,
+        description="Natural language strategy (deprecated, use research_strategy)",
     )
     research_strategy: Optional[str] = Field(
         None, description="Natural language strategy to guide the research phase"
@@ -705,5 +740,3 @@ class BatchListResponse(BaseModel):
     success: bool
     batches: Optional[List[DeepResearchBatch]] = None
     error: Optional[str] = None
-
-


### PR DESCRIPTION
## Summary
- Remove `s3_key` field from `DeliverableResult` model in `valyu/types/deepresearch.py`
- Field exposed internal S3 storage path structure to API consumers - a high-severity information disclosure vulnerability
- The authenticated download `url` field already provides file access without revealing internal storage paths
- No other references to `s3_key` exist in the codebase

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `25581160` |
| **Branch** | `intern/25581160` |

### Original Request
> Fix security vulnerability: s3_key field exposed in DeliverableResult Python model. Reveals internal S3 storage path structure.

Repo: valyu-py
File: valyu/types/deepresearch.py:94
Category: secrets
Severity: high

Test code (must pass after fix):
from pathlib import Path

def test_kevin_20260401_002_s3_key_py():
    content = Path('/workspace/repos/valyu-py/valyu/types/deepresearch.py').read_text()
    assert 's3_key' not in content, 'KEVIN-20260401-002: s3_key still present in valyu-py deepresearch.py'


Apply the minimal fix to resolve this vulnerability. Run the test to confirm it passes.

### Attachments
None
