### PR TITLE
Remove api_key_id and credit_id from DeepResearchBatch model

### DIFF
--- a/valyu/types/deepresearch.py
+++ b/valyu/types/deepresearch.py
@@ -506,8 +506,6 @@ class DeepResearchBatch(BaseModel):
 
     batch_id: str = Field(..., description="Unique batch ID")
     organisation_id: Optional[str] = Field(None, description="Organization ID")
-    api_key_id: Optional[str] = Field(None, description="API key ID")
-    credit_id: Optional[str] = Field(None, description="Credit ID")
     status: BatchStatus = Field(..., description="Current batch status")
     mode: DeepResearchMode = Field(
         ..., description="Research mode (preferred field name)"


### PR DESCRIPTION
## Summary
- Remove `api_key_id` and `credit_id` fields from the `DeepResearchBatch` Pydantic model in `valyu/types/deepresearch.py`
- These are internal database identifiers that were accidentally exposed in the public SDK type definition
- Severity: high - these fields should never be client-facing

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `a709334c` |
| **Branch** | `intern/a709334c` |

### Original Request
> Fix security vulnerability: api_key_id and credit_id fields exposed in DeepResearchBatch interface in both valyu-js and valyu-py SDKs. These are internal database identifiers that should not be client-facing.

Repo: valyu-py
File: valyu/types/deepresearch.py
Category: secrets
Severity: high

### Attachments
None
