### PR TITLE
Remove internal api_key_id and credit_id from DeepResearchBatch model

### DIFF
--- a/valyu/types/deepresearch.py
+++ b/valyu/types/deepresearch.py
@@ -506,8 +506,6 @@ class DeepResearchBatch(BaseModel):
 
     batch_id: str = Field(..., description="Unique batch ID")
     organisation_id: Optional[str] = Field(None, description="Organization ID")
-    api_key_id: Optional[str] = Field(None, description="API key ID")
-    credit_id: Optional[str] = Field(None, description="Credit ID")
     status: BatchStatus = Field(..., description="Current batch status")
     mode: DeepResearchMode = Field(
         ..., description="Research mode (preferred field name)"


### PR DESCRIPTION
## Summary
- Removed `api_key_id` and `credit_id` from the `DeepResearchBatch` Pydantic model in `valyu/types/deepresearch.py`
- These are internal Supabase row IDs (billing/auth identifiers) that should never be exposed to SDK consumers
- Companion fix applied to `valyu-js` (`src/types.ts`) in a separate PR

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `00e3d8ed` |
| **Branch** | `intern/00e3d8ed` |

### Original Request
> Fix security vulnerability: Internal billing/auth identifiers api_key_id and credit_id exposed in public DeepResearchBatch TypeScript type. Also present in valyu-py. These are internal Supabase row IDs that should never be returned to SDK consumers.

### Attachments
None
