### PR TITLE
Add AsyncValyu client and tune sync connection pool

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     },
     install_requires=[
         "requests==2.33.1",
-        "httpx>=0.27,<1.0",
+        "httpx==0.28.1",
         "pydantic==2.12.5",
         "openai==2.30.0",
         "anthropic==0.86.0",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="valyu",
-    version="2.9.4",
+    version="2.9.5",
     author="Valyu",
     author_email="contact@valyu.ai",
     maintainer="Harvey Yorke",
@@ -25,6 +25,7 @@ setup(
     },
     install_requires=[
         "requests==2.33.1",
+        "httpx>=0.27,<1.0",
         "pydantic==2.12.5",
         "openai==2.30.0",
         "anthropic==0.86.0",

--- a/valyu/__init__.py
+++ b/valyu/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.9.4"
+__version__ = "2.9.5"
 
 from .types.response import SearchResponse
 from .types.contents import (
@@ -24,6 +24,7 @@ from .types.deepresearch import (
     DeepResearchRespondResponse,
 )
 from .api import Valyu
+from .async_api import AsyncValyu
 from .providers.openai import OpenAIProvider
 from .providers.anthropic import AnthropicProvider
 from .validation import validate_source, validate_sources, get_source_format_examples
@@ -50,6 +51,7 @@ __all__ = [
     "InteractionHistoryEntry",
     "DeepResearchRespondResponse",
     "Valyu",
+    "AsyncValyu",
     "OpenAIProvider",
     "AnthropicProvider",
     "validate_source",

--- a/valyu/_request_builders.py
+++ b/valyu/_request_builders.py
@@ -1,0 +1,152 @@
+"""
+Pure helpers that build request payloads and validate inputs.
+
+Shared between the sync `Valyu` client (``api.py``) and the async
+``AsyncValyu`` client (``async_api.py``) so validation logic lives in
+one place.
+"""
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from valyu.types.answer import SUPPORTED_COUNTRY_CODES
+from valyu.types.contents import ContentsResponseLength, ExtractEffort
+from valyu.types.response import ResultsBySource, SearchResponse, SearchType
+from valyu.validation import format_validation_error, validate_sources
+
+
+def validate_search_inputs(
+    query: str,
+    included_sources: Optional[List[str]],
+    excluded_sources: Optional[List[str]],
+    country_code: Optional[str],
+) -> Optional[SearchResponse]:
+    """Return a populated SearchResponse if validation fails, otherwise None."""
+    if included_sources is not None:
+        ok, invalid = validate_sources(included_sources)
+        if not ok:
+            return _search_error(
+                query,
+                tx_id="validation-error-included",
+                error=format_validation_error(invalid),
+            )
+
+    if excluded_sources is not None:
+        ok, invalid = validate_sources(excluded_sources)
+        if not ok:
+            return _search_error(
+                query,
+                tx_id="validation-error-excluded",
+                error=format_validation_error(invalid),
+            )
+
+    if country_code is not None and country_code.upper() not in SUPPORTED_COUNTRY_CODES:
+        return _search_error(
+            query,
+            tx_id="validation-error-country",
+            error=(
+                "Invalid country_code. Must be one of: "
+                + ", ".join(sorted(SUPPORTED_COUNTRY_CODES))
+            ),
+        )
+
+    return None
+
+
+def build_search_payload(
+    query: str,
+    search_type: SearchType,
+    max_num_results: int,
+    is_tool_call: Optional[bool],
+    relevance_threshold: Optional[float],
+    max_price: Optional[int],
+    included_sources: Optional[List[str]],
+    excluded_sources: Optional[List[str]],
+    country_code: Optional[str],
+    response_length: Optional[ContentsResponseLength],
+    category: Optional[str],
+    start_date: Optional[str],
+    end_date: Optional[str],
+    fast_mode: bool,
+    url_only: bool,
+    source_biases: Optional[Dict[str, int]],
+    instructions: Optional[str],
+) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "query": query,
+        "search_type": search_type,
+        "max_num_results": max_num_results,
+        "is_tool_call": is_tool_call,
+        "relevance_threshold": relevance_threshold,
+        "fast_mode": fast_mode,
+        "url_only": url_only,
+    }
+    if max_price is not None:
+        payload["max_price"] = max_price
+    if included_sources is not None:
+        payload["included_sources"] = included_sources
+    if excluded_sources is not None:
+        payload["excluded_sources"] = excluded_sources
+    if country_code is not None:
+        payload["country_code"] = country_code.upper()
+    if response_length is not None:
+        payload["response_length"] = response_length
+    if category is not None:
+        payload["category"] = category
+    if start_date is not None:
+        payload["start_date"] = start_date
+    if end_date is not None:
+        payload["end_date"] = end_date
+    if source_biases is not None:
+        payload["source_biases"] = source_biases
+    if instructions is not None:
+        payload["instructions"] = instructions
+    return payload
+
+
+def validate_contents_inputs(urls: List[str], async_mode: bool) -> Tuple[bool, Optional[str]]:
+    if len(urls) > 50:
+        return False, "Maximum 50 URLs allowed per request"
+    if len(urls) > 10 and not async_mode:
+        return False, "Requests with more than 10 URLs require async_mode=True"
+    return True, None
+
+
+def build_contents_payload(
+    urls: List[str],
+    summary: Optional[Union[bool, str, Dict[str, Any]]],
+    extract_effort: Optional[ExtractEffort],
+    response_length: Optional[ContentsResponseLength],
+    max_price_dollars: Optional[float],
+    screenshot: bool,
+    async_mode: bool,
+    webhook_url: Optional[str],
+) -> Dict[str, Any]:
+    use_async = len(urls) > 10 or async_mode
+    payload: Dict[str, Any] = {"urls": urls}
+    if use_async:
+        payload["async"] = True
+    if summary is not None:
+        payload["summary"] = summary
+    if extract_effort is not None:
+        payload["extract_effort"] = extract_effort
+    if response_length is not None:
+        payload["response_length"] = response_length
+    if max_price_dollars is not None:
+        payload["max_price_dollars"] = max_price_dollars
+    if screenshot:
+        payload["screenshot"] = screenshot
+    if webhook_url:
+        payload["webhook_url"] = webhook_url
+    return payload
+
+
+def _search_error(query: str, *, tx_id: str, error: str) -> SearchResponse:
+    return SearchResponse(
+        success=False,
+        error=error,
+        tx_id=tx_id,
+        query=query,
+        results=[],
+        results_by_source=ResultsBySource(web=0, proprietary=0),
+        total_deduction_dollars=0.0,
+        total_characters=0,
+    )

--- a/valyu/api.py
+++ b/valyu/api.py
@@ -481,13 +481,26 @@ class Valyu:
         Returns:
             ContentsJobStatus with current status and results when terminal.
         """
-        response = self._session.get(
-            f"{self.base_url}/contents/jobs/{job_id}",
-            timeout=self._timeout,
-        )
-        data = response.json()
+        try:
+            response = self._session.get(
+                f"{self.base_url}/contents/jobs/{job_id}",
+                timeout=self._timeout,
+            )
+            data = response.json()
 
-        if not response.ok:
+            if not response.ok:
+                return ContentsJobStatus(
+                    success=False,
+                    job_id=job_id,
+                    status="failed",
+                    urls_total=0,
+                    urls_processed=0,
+                    urls_failed=0,
+                    error=data.get("error", f"HTTP Error: {response.status_code}"),
+                )
+
+            return ContentsJobStatus(**data)
+        except Exception as e:
             return ContentsJobStatus(
                 success=False,
                 job_id=job_id,
@@ -495,10 +508,8 @@ class Valyu:
                 urls_total=0,
                 urls_processed=0,
                 urls_failed=0,
-                error=data.get("error", f"HTTP Error: {response.status_code}"),
+                error=str(e) or type(e).__name__,
             )
-
-        return ContentsJobStatus(**data)
 
     def wait_for_contents_job(
         self,

--- a/valyu/api.py
+++ b/valyu/api.py
@@ -4,6 +4,7 @@ import platform
 import time
 
 import requests
+from requests.adapters import HTTPAdapter
 from valyu import __version__
 from typing import Optional, List, Union, Dict, Any, Callable
 from valyu.types.response import SearchResponse, SearchType, ResultsBySource
@@ -44,13 +45,36 @@ class Valyu:
         self,
         api_key: Optional[str] = None,
         base_url: str = "https://api.valyu.ai/v1",
+        max_connections: int = 100,
+        timeout: Optional[float] = 600.0,
+        session: Optional[requests.Session] = None,
     ):
         """
         Initialize the Valyu client.
 
         Args:
-            api_key (Optional[str]): The API key to use for the client. If not provided, will attempt to read from VALYU_API_KEY environment variable.
+            api_key (Optional[str]): The API key to use for the client. If not
+                provided, will attempt to read from ``VALYU_API_KEY`` environment
+                variable.
             base_url (str): The base URL for the Valyu API.
+            max_connections (int): Maximum number of simultaneous HTTP
+                connections the underlying session will pool. Raise this when
+                calling the client from many threads; lower it if you want to be
+                gentle on a constrained environment. Defaults to 100. Ignored
+                when ``session`` is provided.
+            timeout (Optional[float]): Per-request timeout in seconds. Applied
+                to every outbound request unless overridden on the call. Pass
+                ``None`` to disable the timeout. Defaults to 600 seconds.
+            session (Optional[requests.Session]): Pre-configured
+                ``requests.Session`` to use. When provided, the client is used
+                as-is (no adapters mounted) and is NOT closed by ``close()`` —
+                lifecycle stays with the caller. Useful for injecting proxies,
+                custom TLS config, or a shared pool across clients.
+
+        The client may be used as a context manager::
+
+            with Valyu() as valyu:
+                response = valyu.search("...")
         """
         if api_key is None:
             api_key = os.getenv("VALYU_API_KEY")
@@ -58,6 +82,7 @@ class Valyu:
                 raise ValueError("VALYU_API_KEY is not set")
 
         self.base_url = base_url
+        self._timeout = timeout
         self.headers = {
             "Content-Type": "application/json",
             "x-api-key": api_key,
@@ -66,15 +91,44 @@ class Valyu:
             "X-Valyu-SDK-Version": __version__,
         }
 
-        # Persistent session for TCP+TLS connection reuse
-        self._session = requests.Session()
-        self._session.headers.update(self.headers)
+        if session is not None:
+            self._session = session
+            self._owns_session = False
+            # Ensure required headers are present without clobbering caller's.
+            for key, value in self.headers.items():
+                self._session.headers.setdefault(key, value)
+        else:
+            self._session = requests.Session()
+            self._session.headers.update(self.headers)
+            adapter = HTTPAdapter(
+                pool_connections=max_connections,
+                pool_maxsize=max_connections,
+                max_retries=0,
+            )
+            self._session.mount("https://", adapter)
+            self._session.mount("http://", adapter)
+            self._owns_session = True
 
         # Initialize DeepResearch client
         self.deepresearch = DeepResearchClient(self)
 
         # Initialize Batch client
         self.batch = BatchClient(self)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def close(self) -> None:
+        """Release the underlying HTTP session if this client owns it."""
+        if self._owns_session:
+            self._session.close()
+
+    def __enter__(self) -> "Valyu":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
 
     def search(
         self,
@@ -223,7 +277,9 @@ class Valyu:
                 payload["instructions"] = instructions
 
             response = self._session.post(
-                f"{self.base_url}/search", json=payload
+                f"{self.base_url}/search",
+                json=payload,
+                timeout=self._timeout,
             )
 
             data = response.json()
@@ -371,7 +427,9 @@ class Valyu:
                 payload["webhook_url"] = webhook_url
 
             response = self._session.post(
-                f"{self.base_url}/contents", json=payload
+                f"{self.base_url}/contents",
+                json=payload,
+                timeout=self._timeout,
             )
 
             data = response.json()
@@ -425,6 +483,7 @@ class Valyu:
         """
         response = self._session.get(
             f"{self.base_url}/contents/jobs/{job_id}",
+            timeout=self._timeout,
         )
         data = response.json()
 

--- a/valyu/async_api.py
+++ b/valyu/async_api.py
@@ -226,7 +226,7 @@ class AsyncValyu:
             response = await self._post("/search", payload)
             data = response.json()
 
-            if response.status_code < 200 or response.status_code >= 300:
+            if not (200 <= response.status_code < 400):
                 return SearchResponse(
                     success=False,
                     error=data.get("error", f"HTTP Error: {response.status_code}"),
@@ -318,7 +318,7 @@ class AsyncValyu:
             response = await self._post("/contents", payload)
             data = response.json()
 
-            if response.status_code < 200 or response.status_code >= 300:
+            if not (200 <= response.status_code < 400):
                 return ContentsResponse(
                     success=False,
                     error=data.get("error", f"HTTP Error: {response.status_code}"),
@@ -362,7 +362,7 @@ class AsyncValyu:
             response = await self._get(f"/contents/jobs/{job_id}")
             data = response.json()
 
-            if response.status_code < 200 or response.status_code >= 300:
+            if not (200 <= response.status_code < 400):
                 return ContentsJobStatus(
                     success=False,
                     job_id=job_id,

--- a/valyu/async_api.py
+++ b/valyu/async_api.py
@@ -1,0 +1,416 @@
+"""
+Async Valyu client for high-concurrency applications.
+
+Built on ``httpx.AsyncClient`` so many calls can be in flight concurrently
+inside a single event loop without thread overhead or per-request TLS
+handshakes. Currently exposes ``search`` and ``contents`` (plus the two
+``contents`` job helpers); other endpoints remain on the sync client for
+now.
+
+Typical usage::
+
+    import asyncio
+    from valyu import AsyncValyu
+
+    async def main():
+        async with AsyncValyu() as valyu:
+            response = await valyu.search(
+                "Real options valuation binomial Monte Carlo",
+                included_sources=["wiley/wiley-finance-papers"],
+                max_num_results=10,
+            )
+            print(response)
+
+    asyncio.run(main())
+"""
+import asyncio
+import os
+import platform
+import time
+from types import TracebackType
+from typing import Any, Callable, Dict, List, Optional, Type, Union
+
+import httpx
+
+from valyu import __version__
+from valyu._request_builders import (
+    build_contents_payload,
+    build_search_payload,
+    validate_contents_inputs,
+    validate_search_inputs,
+)
+from valyu.types.contents import (
+    ContentsJobCreateResponse,
+    ContentsJobStatus,
+    ContentsResponse,
+    ContentsResponseLength,
+    ExtractEffort,
+)
+from valyu.types.response import ResultsBySource, SearchResponse, SearchType
+
+
+def _format_exception(exc: BaseException) -> str:
+    """Return a non-empty human-readable description of an exception.
+
+    Some exception classes (notably ``httpx.TimeoutException``) have an empty
+    ``str`` representation, so fall back to the class name when that happens.
+    """
+    message = str(exc).strip()
+    if message:
+        return message
+    return type(exc).__name__
+
+
+class AsyncValyu:
+    """Async Valyu client backed by ``httpx.AsyncClient``."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: str = "https://api.valyu.ai/v1",
+        max_connections: int = 100,
+        max_keepalive_connections: Optional[int] = None,
+        timeout: float = 600.0,
+        http_client: Optional[httpx.AsyncClient] = None,
+    ):
+        """
+        Initialize the async Valyu client.
+
+        Args:
+            api_key (Optional[str]): API key. Falls back to ``VALYU_API_KEY``
+                env var.
+            base_url (str): Base URL of the Valyu API.
+            max_connections (int): Maximum simultaneous connections the
+                underlying HTTP pool will open. Only used when
+                ``http_client`` is not provided. Defaults to 100.
+            max_keepalive_connections (Optional[int]): Number of idle
+                connections kept alive for reuse. Defaults to
+                ``max(20, max_connections // 5)``.
+            timeout (float): Per-request timeout in seconds. Applies to
+                the default client; ignored when ``http_client`` is passed.
+            http_client (Optional[httpx.AsyncClient]): Pre-configured
+                ``httpx.AsyncClient`` to use. When provided, the client is
+                used as-is and is NOT closed by ``aclose()`` — ownership
+                stays with the caller.
+        """
+        if api_key is None:
+            api_key = os.getenv("VALYU_API_KEY")
+            if not api_key:
+                raise ValueError("VALYU_API_KEY is not set")
+
+        # Normalise base_url so joining with a leading-slash path never
+        # produces "//" in the URL.
+        self.base_url = base_url.rstrip("/")
+        self._headers = {
+            "Content-Type": "application/json",
+            "x-api-key": api_key,
+            "User-Agent": f"valyu-py/{__version__} python/{platform.python_version()}",
+            "X-Valyu-SDK": "valyu-py-async",
+            "X-Valyu-SDK-Version": __version__,
+        }
+
+        if http_client is not None:
+            self._client = http_client
+            self._owns_client = False
+        else:
+            if max_keepalive_connections is None:
+                max_keepalive_connections = max(20, max_connections // 5)
+            limits = httpx.Limits(
+                max_connections=max_connections,
+                max_keepalive_connections=max_keepalive_connections,
+            )
+            self._client = httpx.AsyncClient(
+                base_url=self.base_url,
+                headers=self._headers,
+                limits=limits,
+                timeout=timeout,
+            )
+            self._owns_client = True
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client, if this instance owns it."""
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def __aenter__(self) -> "AsyncValyu":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc: Optional[BaseException],
+        tb: Optional[TracebackType],
+    ) -> None:
+        await self.aclose()
+
+    # ------------------------------------------------------------------
+    # Internal request helpers
+    # ------------------------------------------------------------------
+
+    async def _post(self, path: str, payload: Dict[str, Any]) -> httpx.Response:
+        if self._owns_client:
+            return await self._client.post(path, json=payload)
+        # External client: base_url may not be set on it, so send full URL.
+        return await self._client.post(
+            f"{self.base_url}{path}", json=payload, headers=self._headers
+        )
+
+    async def _get(self, path: str) -> httpx.Response:
+        if self._owns_client:
+            return await self._client.get(path)
+        return await self._client.get(f"{self.base_url}{path}", headers=self._headers)
+
+    # ------------------------------------------------------------------
+    # Search
+    # ------------------------------------------------------------------
+
+    async def search(
+        self,
+        query: str,
+        search_type: SearchType = "all",
+        max_num_results: int = 10,
+        is_tool_call: Optional[bool] = True,
+        relevance_threshold: Optional[float] = 0.5,
+        max_price: Optional[int] = None,
+        included_sources: Optional[List[str]] = None,
+        excluded_sources: Optional[List[str]] = None,
+        country_code: Optional[str] = None,
+        response_length: Optional[ContentsResponseLength] = None,
+        category: Optional[str] = None,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        fast_mode: bool = False,
+        url_only: bool = False,
+        source_biases: Optional[Dict[str, int]] = None,
+        instructions: Optional[str] = None,
+    ) -> Optional[SearchResponse]:
+        """
+        Async version of ``Valyu.search``. See :py:meth:`Valyu.search`
+        for full parameter documentation — arguments and semantics are
+        identical.
+        """
+        try:
+            invalid = validate_search_inputs(
+                query=query,
+                included_sources=included_sources,
+                excluded_sources=excluded_sources,
+                country_code=country_code,
+            )
+            if invalid is not None:
+                return invalid
+
+            payload = build_search_payload(
+                query=query,
+                search_type=search_type,
+                max_num_results=max_num_results,
+                is_tool_call=is_tool_call,
+                relevance_threshold=relevance_threshold,
+                max_price=max_price,
+                included_sources=included_sources,
+                excluded_sources=excluded_sources,
+                country_code=country_code,
+                response_length=response_length,
+                category=category,
+                start_date=start_date,
+                end_date=end_date,
+                fast_mode=fast_mode,
+                url_only=url_only,
+                source_biases=source_biases,
+                instructions=instructions,
+            )
+
+            response = await self._post("/search", payload)
+            data = response.json()
+
+            if response.status_code < 200 or response.status_code >= 300:
+                return SearchResponse(
+                    success=False,
+                    error=data.get("error", f"HTTP Error: {response.status_code}"),
+                    tx_id=data.get("tx_id", f"error-{response.status_code}"),
+                    query=query,
+                    results=[],
+                    results_by_source=ResultsBySource(web=0, proprietary=0),
+                    total_deduction_dollars=0.0,
+                    total_characters=0,
+                )
+
+            if not data.get("results") and data.get("error"):
+                return SearchResponse(
+                    success=True,
+                    error=data.get("error"),
+                    tx_id=data.get("tx_id", "0x0"),
+                    query=data.get("query", query),
+                    results=[],
+                    results_by_source=data.get(
+                        "results_by_source",
+                        ResultsBySource(web=0, proprietary=0),
+                    ),
+                    total_deduction_dollars=data.get("total_deduction_dollars", 0.0),
+                    total_characters=data.get("total_characters", 0),
+                )
+
+            return SearchResponse(**data)
+        except Exception as exc:
+            message = _format_exception(exc)
+            return SearchResponse(
+                success=False,
+                error=message,
+                tx_id="exception-" + str(hash(message))[:8],
+                query=query,
+                results=[],
+                results_by_source=ResultsBySource(web=0, proprietary=0),
+                total_deduction_dollars=0.0,
+                total_characters=0,
+            )
+
+    # ------------------------------------------------------------------
+    # Contents
+    # ------------------------------------------------------------------
+
+    async def contents(
+        self,
+        urls: List[str],
+        summary: Optional[Union[bool, str, Dict[str, Any]]] = None,
+        extract_effort: Optional[ExtractEffort] = None,
+        response_length: Optional[ContentsResponseLength] = None,
+        max_price_dollars: Optional[float] = None,
+        screenshot: bool = False,
+        async_mode: bool = False,
+        webhook_url: Optional[str] = None,
+        wait: bool = False,
+        poll_interval: int = 5,
+        max_wait_time: int = 3600,
+    ) -> Optional[Union[ContentsResponse, ContentsJobCreateResponse, ContentsJobStatus]]:
+        """
+        Async version of ``Valyu.contents``. Arguments and semantics
+        identical to :py:meth:`Valyu.contents`.
+        """
+        try:
+            ok, err = validate_contents_inputs(urls, async_mode)
+            if not ok:
+                return ContentsResponse(
+                    success=False,
+                    error=err,
+                    tx_id="error-max-urls" if len(urls) > 50 else "error-async-required",
+                    urls_requested=len(urls),
+                    urls_processed=0,
+                    urls_failed=len(urls),
+                    results=[],
+                    total_cost_dollars=0.0,
+                    total_characters=0,
+                )
+
+            payload = build_contents_payload(
+                urls=urls,
+                summary=summary,
+                extract_effort=extract_effort,
+                response_length=response_length,
+                max_price_dollars=max_price_dollars,
+                screenshot=screenshot,
+                async_mode=async_mode,
+                webhook_url=webhook_url,
+            )
+
+            response = await self._post("/contents", payload)
+            data = response.json()
+
+            if response.status_code < 200 or response.status_code >= 300:
+                return ContentsResponse(
+                    success=False,
+                    error=data.get("error", f"HTTP Error: {response.status_code}"),
+                    tx_id=data.get("tx_id", f"error-{response.status_code}"),
+                    urls_requested=len(urls),
+                    urls_processed=0,
+                    urls_failed=len(urls),
+                    results=[],
+                    total_cost_dollars=0.0,
+                    total_characters=0,
+                )
+
+            if response.status_code == 202:
+                job = ContentsJobCreateResponse(**data)
+                if wait and job.success:
+                    return await self.wait_for_contents_job(
+                        job.job_id,
+                        poll_interval=poll_interval,
+                        max_wait_time=max_wait_time,
+                    )
+                return job
+
+            return ContentsResponse(**data)
+        except Exception as exc:
+            message = _format_exception(exc)
+            return ContentsResponse(
+                success=False,
+                error=message,
+                tx_id="exception-" + str(hash(message))[:8],
+                urls_requested=len(urls),
+                urls_processed=0,
+                urls_failed=len(urls),
+                results=[],
+                total_cost_dollars=0.0,
+                total_characters=0,
+            )
+
+    async def get_contents_job(self, job_id: str) -> ContentsJobStatus:
+        """Async version of :py:meth:`Valyu.get_contents_job`."""
+        try:
+            response = await self._get(f"/contents/jobs/{job_id}")
+            data = response.json()
+
+            if response.status_code < 200 or response.status_code >= 300:
+                return ContentsJobStatus(
+                    success=False,
+                    job_id=job_id,
+                    status="failed",
+                    urls_total=0,
+                    urls_processed=0,
+                    urls_failed=0,
+                    error=data.get("error", f"HTTP Error: {response.status_code}"),
+                )
+
+            return ContentsJobStatus(**data)
+        except Exception as exc:
+            return ContentsJobStatus(
+                success=False,
+                job_id=job_id,
+                status="failed",
+                urls_total=0,
+                urls_processed=0,
+                urls_failed=0,
+                error=_format_exception(exc),
+            )
+
+    async def wait_for_contents_job(
+        self,
+        job_id: str,
+        poll_interval: int = 5,
+        max_wait_time: int = 3600,
+        on_progress: Optional[Callable[[ContentsJobStatus], None]] = None,
+    ) -> ContentsJobStatus:
+        """Async version of :py:meth:`Valyu.wait_for_contents_job`."""
+        start_time = time.time()
+        terminal = ("completed", "partial", "failed")
+
+        while True:
+            status = await self.get_contents_job(job_id)
+
+            if not status.success:
+                raise ValueError(f"Failed to get job status: {status.error}")
+
+            if on_progress is not None:
+                on_progress(status)
+
+            if status.status in terminal:
+                return status
+
+            if time.time() - start_time > max_wait_time:
+                raise TimeoutError(
+                    f"Job did not complete within {max_wait_time} seconds"
+                )
+
+            await asyncio.sleep(poll_interval)


### PR DESCRIPTION
## Summary

- Adds a new `AsyncValyu` client built on `httpx.AsyncClient` covering `search`, `contents`, `get_contents_job`, and `wait_for_contents_job`, with `async with` / `aclose` lifecycle support and an optional caller-provided `http_client`.
- Tunes the existing sync `Valyu` client so it no longer bottlenecks at `requests`' default 10-connection pool: mounts an `HTTPAdapter` with `pool_maxsize=100` and exposes `max_connections`, `timeout`, and `session` kwargs. Adds `close()` and `with` context-manager support.
- Pulls request-payload construction and input validation into `valyu/_request_builders.py` so the sync and async clients share a single source of truth.
- Bumps version to 2.9.5.

## Public API additions

```python
from valyu import AsyncValyu

async with AsyncValyu() as valyu:
    response = await valyu.search("quantum computing", max_num_results=10)
```

```python
from valyu import Valyu

with Valyu(max_connections=100, timeout=30.0) as valyu:
    response = valyu.search("quantum computing")
```

Both clients accept an optional caller-owned HTTP client (`http_client=` / `session=`) for injecting proxies, custom TLS, or a shared connection pool.

## Test plan

- [ ] `pip install -e .` and `from valyu import AsyncValyu` imports cleanly
- [ ] Sync context manager: `with Valyu() as v: v.search(...)` closes session
- [ ] Sync `close()` is idempotent (callable twice without error)
- [ ] Sync accepts external `requests.Session`; client's `close()` does not close caller's session
- [ ] Async context manager: `async with AsyncValyu() as v: await v.search(...)` closes httpx client
- [ ] Async `aclose()` is idempotent
- [ ] Async accepts external `httpx.AsyncClient`; client's `aclose()` does not close caller's client
- [ ] `max_connections` kwarg honored on sync (via HTTPAdapter) and async (via httpx.Limits)
- [ ] `timeout` kwarg wired through to every sync `/search`, `/contents`, `/contents/jobs/{id}` call
- [ ] Async timeout produces a non-empty error string (falls back to exception class name)
- [ ] Shared `_request_builders` validation: invalid `included_sources` returns expected `SearchResponse(success=False)`