### PR TITLE
Remove internal billing IDs from public DeepResearchBatch type

### DIFF
--- a/valyu/types/deepresearch.py
+++ b/valyu/types/deepresearch.py
@@ -506,8 +506,6 @@ class DeepResearchBatch(BaseModel):
 
     batch_id: str = Field(..., description="Unique batch ID")
     organisation_id: Optional[str] = Field(None, description="Organization ID")
-    api_key_id: Optional[str] = Field(None, description="API key ID")
-    credit_id: Optional[str] = Field(None, description="Credit ID")
     status: BatchStatus = Field(..., description="Current batch status")
     mode: DeepResearchMode = Field(
         ..., description="Research mode (preferred field name)"


### PR DESCRIPTION
## Summary
- Removed `api_key_id` and `credit_id` fields from the public `DeepResearchBatch` Pydantic model in `valyu/types/deepresearch.py`
- These are internal billing identifiers that should not be exposed in the public SDK - their presence enabled account enumeration and billing manipulation
- Corresponding fix applied in valyu-js (`src/types.ts`) in a separate PR

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `582617aa` |
| **Branch** | `intern/582617aa` |

### Original Request
> Fix security vulnerability: Internal billing identifiers api_key_id and credit_id are exposed in the public DeepResearchBatch type in both valyu-js (PUBLIC repo) and valyu-py (PUBLIC repo). These internal IDs could be used for account enumeration or billing manipulation.

Category: config
Severity: high

### Attachments
None
