### PR TITLE
Fix Deep Research chart_type validation error (radar/heatmap/etc.)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="valyu",
-    version="2.9.5",
+    version="2.9.6",
     author="Valyu",
     author_email="contact@valyu.ai",
     maintainer="Harvey Yorke",

--- a/valyu/types/deepresearch.py
+++ b/valyu/types/deepresearch.py
@@ -165,6 +165,9 @@ class ChartDataPoint(BaseModel):
 
     x: Union[str, int, float]
     y: Union[int, float]
+    y2: Optional[Union[int, float]] = None
+    z: Optional[Union[int, float]] = None
+    values: Optional[List[Union[int, float]]] = None
 
 
 class ChartDataSeries(BaseModel):
@@ -172,6 +175,7 @@ class ChartDataSeries(BaseModel):
 
     name: str
     data: List[ChartDataPoint]
+    line_style: Optional[Literal["solid", "dashed", "dotted"]] = None
 
 
 class DeepResearchTools(BaseModel):
@@ -193,7 +197,26 @@ class ImageMetadata(BaseModel):
     # Screenshot-only fields
     source_url: Optional[str] = None
     captured_at: Optional[int] = None
-    chart_type: Optional[Literal["line", "bar", "area"]] = None
+    chart_type: Optional[
+        Literal[
+            "line",
+            "bar",
+            "area",
+            "pie",
+            "doughnut",
+            "radar",
+            "scatter",
+            "horizontalBar",
+            "heatmap",
+            "boxplot",
+            "stackedBar",
+            "stackedArea",
+            "histogram",
+            "waterfall",
+            "timeline",
+            "bubble",
+        ]
+    ] = None
     x_axis_label: Optional[str] = None
     y_axis_label: Optional[str] = None
     data_series: Optional[List[ChartDataSeries]] = None


### PR DESCRIPTION
## Summary

The Deep Research server emits 16 chart types, but the Python SDK's Pydantic model only allowed `line | bar | area`. Any response containing a newer chart type (e.g. `radar` from a recent server change) now fails with:

\`\`\`
1 validation error for DeepResearchStatusResponse
images.0.chart_type
  Input should be 'line', 'bar' or 'area' [type=literal_error, input_value='radar']
\`\`\`

This PR brings the SDK to parity with the server in \`infrastructure/servers/deepresearch/src/types.ts\`:

- \`ImageMetadata.chart_type\`: add \`pie, doughnut, radar, scatter, horizontalBar, heatmap, boxplot, stackedBar, stackedArea, histogram, waterfall, timeline, bubble\`
- \`ChartDataPoint\`: add optional \`y2\` (timeline end), \`z\` (bubble size), \`values\` (boxplot raw data)
- \`ChartDataSeries\`: add optional \`line_style\` (\`solid | dashed | dotted\`)
- Bump \`2.9.5 -> 2.9.6\`

All additions are optional / additive — backwards compatible with existing payloads.

## Test plan

- [x] \`from valyu.types.deepresearch import ImageMetadata\` parses a chart with \`chart_type='radar'\`, \`y2\`, \`z\`, \`values\`, and \`line_style='dashed'\` without error
- [ ] CI passes