### PR TITLE
Add charts flag to DeepResearchTools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="valyu",
-    version="2.9.5",
+    version="2.9.7",
     author="Valyu",
     author_email="contact@valyu.ai",
     maintainer="Harvey Yorke",

--- a/valyu/types/deepresearch.py
+++ b/valyu/types/deepresearch.py
@@ -179,6 +179,7 @@ class DeepResearchTools(BaseModel):
 
     code_execution: Optional[bool] = Field(False, description="Enable code execution in sandboxed environment")
     screenshots: Optional[bool] = Field(False, description="Enable visual screenshot capture of web pages")
+    charts: Optional[bool] = Field(False, description="Enable chart/graph generation embedded in the final report (free)")
 
 
 class ImageMetadata(BaseModel):


### PR DESCRIPTION
## Summary

Adds the new `charts` opt-in to `DeepResearchTools`, mirroring an upcoming server-side change that makes chart generation a toggleable Deep Research tool.

```python
from valyu.types.deepresearch import DeepResearchTools

DeepResearchTools(code_execution=False, screenshots=False, charts=True)
```

- Free — no per-call surcharge
- Default `False` to match the server default

Bumps `2.9.5 -> 2.9.7`. Skipping `2.9.6` because that version was reserved for the in-flight chart-types parity PR (#113); whichever merged first owned its bump number.

## Test plan

- [x] `DeepResearchTools(charts=True).model_dump()` round-trips
- [ ] Server change merged before publishing this version (otherwise the field is silently dropped by the API)