### PR TITLE
Add optional fragment field to DeepResearchSource

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="valyu",
-    version="2.9.7",
+    version="2.9.8",
     author="Valyu",
     author_email="contact@valyu.ai",
     maintainer="Harvey Yorke",

--- a/valyu/types/deepresearch.py
+++ b/valyu/types/deepresearch.py
@@ -239,6 +239,7 @@ class DeepResearchSource(BaseModel):
     category: Optional[str] = None
     source_id: Optional[int] = None
     word_count: Optional[int] = None
+    fragment: Optional[str] = None
 
 
 class Usage(BaseModel):


### PR DESCRIPTION
## Summary

- Adds optional `fragment: Optional[str] = None` to `DeepResearchSource` Pydantic model.
- Bumps version to `2.9.8` (patch).

## Field

`fragment` is an optional URL fragment that, when appended to `url`, produces a deep-link to the cited passage on the source page (Scroll-to-Text-Fragment for HTML, PDF Open Parameters for PDF). Field is omitted when no reliable highlight target is available — clients fall back to the canonical `url`.

Purely additive — no breaking change. Existing consumers ignore the field.

## Test plan

- [ ] `pip install -e .` and confirm `from valyu.types import DeepResearchSource` exposes `.fragment`
- [ ] Confirm a Deep Research response with no `fragment` still parses (defaults to `None`)
- [ ] Confirm a response containing `fragment` populates the attribute