### PR TITLE
Remove unused anthropic/openai deps and relax version pins

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="valyu",
-    version="2.9.9",
+    version="2.9.10",
     author="Valyu",
     author_email="contact@valyu.ai",
     maintainer="Harvey Yorke",
@@ -24,11 +24,9 @@ setup(
         "": ["*.pyc", "*.pyo", "*.pyd", "__pycache__", "*.so"],
     },
     install_requires=[
-        "requests==2.33.1",
-        "httpx==0.28.1",
-        "pydantic==2.12.5",
-        "openai==2.30.0",
-        "anthropic==0.86.0",
+        "requests>=2.31.0",
+        "httpx>=0.27.0",
+        "pydantic>=2.0.0",
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Summary
- `AnthropicProvider` and `OpenAIProvider` duck-type response objects via `getattr`/`hasattr` and never `import anthropic` or `import openai`. The exact pins `anthropic==0.86.0` and `openai==2.30.0` in `install_requires` were forcing dependency conflicts on every downstream project for no benefit — users had to override our pins to use a different anthropic/openai version.
- Relax `requests`, `httpx`, `pydantic` from `==` exact pins to `>=` minimum bounds. Exact pins are appropriate for applications, not libraries; they break pip's resolver for downstream users.
- Patch bump `2.9.9` → `2.9.10`.

## Verification
```
$ grep -rn "^import anthropic\|^from anthropic\|^import openai\|^from openai" valyu/
# (no matches)
```

## Test plan
- [ ] `pip install -e .` in a fresh venv resolves cleanly
- [ ] Existing examples in `examples/` still run (AnthropicProvider / OpenAIProvider only need the user's own `anthropic` / `openai` install)
- [ ] No regressions in `valyu/providers/anthropic.py` or `valyu/providers/openai.py`