### PR TITLE
Remove internal routing metadata from SDK response types

### DIFF
--- a/tests/test_sdk_api_parity.py
+++ b/tests/test_sdk_api_parity.py
@@ -1,0 +1,35 @@
+"""
+Tests that SDK response types do not expose internal routing metadata to end users.
+"""
+
+from valyu.types.deepresearch import DeepResearchBatch, DeepResearchSource
+from valyu.types.response import SearchResult
+
+
+def test_py_response_no_internal_leak():
+    """Ensure SDK response models strip internal routing metadata before returning to users."""
+    # DeepResearchBatch must not expose internal billing/auth routing fields
+    batch_fields = set(DeepResearchBatch.model_fields)
+    assert (
+        "api_key_id" not in batch_fields
+    ), "api_key_id is internal and must not be exposed"
+    assert (
+        "credit_id" not in batch_fields
+    ), "credit_id is internal and must not be exposed"
+    assert (
+        "organisation_id" not in batch_fields
+    ), "organisation_id is internal and must not be exposed"
+
+    # DeepResearchSource must not expose internal routing identifiers
+    source_fields = set(DeepResearchSource.model_fields)
+    assert "org_id" not in source_fields, "org_id is internal and must not be exposed"
+    assert (
+        "source_id" not in source_fields
+    ), "source_id is internal and must not be exposed"
+    assert "doc_id" not in source_fields, "doc_id is internal and must not be exposed"
+
+    # SearchResult must not expose catch-all internal metadata dict
+    result_fields = set(SearchResult.model_fields)
+    assert (
+        "metadata" not in result_fields
+    ), "metadata catch-all dict must not be exposed"

--- a/valyu/types/deepresearch.py
+++ b/valyu/types/deepresearch.py
@@ -145,7 +145,8 @@ class SearchConfig(BaseModel):
     )
     category: Optional[str] = Field(None, description="Category filter for results")
     country_code: Optional[str] = Field(
-        None, description="ISO country code for location-filtered searches (e.g., 'US', 'GB')"
+        None,
+        description="ISO country code for location-filtered searches (e.g., 'US', 'GB')",
     )
     source_biases: Optional[Dict[str, int]] = Field(
         None,
@@ -182,7 +183,10 @@ class ToolConfig(BaseModel):
     """Per-tool configuration with optional call limit."""
 
     enabled: Optional[bool] = Field(True, description="Enable or disable the tool")
-    max_calls: Optional[int] = Field(None, description="Max invocations per task. Capped at system default if exceeded.")
+    max_calls: Optional[int] = Field(
+        None,
+        description="Max invocations per task. Capped at system default if exceeded.",
+    )
 
 
 class DeepResearchTools(BaseModel):
@@ -200,10 +204,19 @@ class DeepResearchTools(BaseModel):
     Setting max_calls: 0 effectively disables the tool.
     """
 
-    code_execution: Optional[Union[bool, ToolConfig]] = Field(None, description="Enable code execution in sandboxed environment")
-    screenshots: Optional[Union[bool, ToolConfig]] = Field(None, description="Enable visual screenshot capture of web pages")
-    browser_use: Optional[Union[bool, ToolConfig]] = Field(None, description="Enable autonomous browser sessions")
-    charts: Optional[Union[bool, ToolConfig]] = Field(None, description="Enable chart/graph generation embedded in the final report (free, unlimited)")
+    code_execution: Optional[Union[bool, ToolConfig]] = Field(
+        None, description="Enable code execution in sandboxed environment"
+    )
+    screenshots: Optional[Union[bool, ToolConfig]] = Field(
+        None, description="Enable visual screenshot capture of web pages"
+    )
+    browser_use: Optional[Union[bool, ToolConfig]] = Field(
+        None, description="Enable autonomous browser sessions"
+    )
+    charts: Optional[Union[bool, ToolConfig]] = Field(
+        None,
+        description="Enable chart/graph generation embedded in the final report (free, unlimited)",
+    )
 
 
 class ImageMetadata(BaseModel):
@@ -251,13 +264,10 @@ class DeepResearchSource(BaseModel):
     snippet: Optional[str] = None
     description: Optional[str] = None
     source: Optional[str] = None
-    org_id: Optional[str] = None
     price: Optional[float] = None
     id: Optional[str] = None
-    doc_id: Optional[int] = None
     doi: Optional[str] = None
     category: Optional[str] = None
-    source_id: Optional[int] = None
     word_count: Optional[int] = None
     fragment: Optional[str] = None
 
@@ -276,9 +286,16 @@ class DeepResearchCostBreakdown(BaseModel):
     """Itemized cost breakdown for a deep research task."""
 
     task: float = Field(..., description="Base task price for the selected mode")
-    screenshots: Optional[float] = Field(None, description="Screenshot surcharges ($0.05 per URL captured)")
-    code_execution: Optional[float] = Field(None, description="Code execution surcharges ($0.10 per execution)")
-    deliverables: Optional[float] = Field(None, description="Deliverable surcharges ($0.10 per deliverable after the first)")
+    screenshots: Optional[float] = Field(
+        None, description="Screenshot surcharges ($0.05 per URL captured)"
+    )
+    code_execution: Optional[float] = Field(
+        None, description="Code execution surcharges ($0.10 per execution)"
+    )
+    deliverables: Optional[float] = Field(
+        None,
+        description="Deliverable surcharges ($0.10 per deliverable after the first)",
+    )
 
 
 class HitlConfig(BaseModel):
@@ -298,7 +315,8 @@ class HitlConfig(BaseModel):
         None, description="Pause after research for user to filter sources by domain"
     )
     outline_review: Optional[bool] = Field(
-        None, description="Pause after source review for user to review the report outline"
+        None,
+        description="Pause after source review for user to review the report outline",
     )
 
 
@@ -314,10 +332,14 @@ class InteractionType(str, Enum):
 class Interaction(BaseModel):
     """HITL interaction payload returned when a task is awaiting input."""
 
-    interaction_id: str = Field(..., description="Unique ID for this interaction (use when responding)")
+    interaction_id: str = Field(
+        ..., description="Unique ID for this interaction (use when responding)"
+    )
     type: InteractionType = Field(..., description="Type of checkpoint")
     data: Dict[str, Any] = Field(..., description="Checkpoint-specific data")
-    created_at: int = Field(..., description="Unix timestamp (ms) when checkpoint fired")
+    created_at: int = Field(
+        ..., description="Unix timestamp (ms) when checkpoint fired"
+    )
     timeout_ms: int = Field(..., description="Timeout duration in milliseconds")
     expected_response: Optional[Dict[str, Any]] = Field(
         None, description="Schema hint for the expected response shape"
@@ -330,9 +352,15 @@ class InteractionHistoryEntry(BaseModel):
     interaction_id: str
     type: InteractionType
     created_at: int = Field(..., description="When the checkpoint fired (ms)")
-    responded_at: Optional[int] = Field(None, description="When the user responded (ms)")
-    auto_continued: bool = Field(..., description="True if timed out, false if user responded")
-    response: Optional[Dict[str, Any]] = Field(None, description="The user's response (absent if timed out)")
+    responded_at: Optional[int] = Field(
+        None, description="When the user responded (ms)"
+    )
+    auto_continued: bool = Field(
+        ..., description="True if timed out, false if user responded"
+    )
+    response: Optional[Dict[str, Any]] = Field(
+        None, description="The user's response (absent if timed out)"
+    )
 
 
 class DeepResearchCreateResponse(BaseModel):
@@ -377,15 +405,27 @@ class DeepResearchStatusResponse(BaseModel):
     deliverables: Optional[List[DeliverableResult]] = None
     sources: Optional[List[DeepResearchSource]] = None
     cost: Optional[float] = None
-    cost_breakdown: Optional[DeepResearchCostBreakdown] = Field(None, description="Itemized cost breakdown (task, screenshots, code_execution, deliverables)")
-    tools: Optional[DeepResearchTools] = Field(None, description="Resolved tools configuration")
+    cost_breakdown: Optional[DeepResearchCostBreakdown] = Field(
+        None,
+        description="Itemized cost breakdown (task, screenshots, code_execution, deliverables)",
+    )
+    tools: Optional[DeepResearchTools] = Field(
+        None, description="Resolved tools configuration"
+    )
     batch_id: Optional[str] = None
     batch_task_id: Optional[str] = None
 
     # HITL fields
-    hitl_config: Optional[Dict[str, Any]] = Field(None, description="HITL configuration (mirrors request hitl param)")
-    interaction: Optional[Interaction] = Field(None, description="Current HITL checkpoint (present when awaiting_input or paused)")
-    hitl_history: Optional[List[InteractionHistoryEntry]] = Field(None, description="History of completed HITL checkpoints")
+    hitl_config: Optional[Dict[str, Any]] = Field(
+        None, description="HITL configuration (mirrors request hitl param)"
+    )
+    interaction: Optional[Interaction] = Field(
+        None,
+        description="Current HITL checkpoint (present when awaiting_input or paused)",
+    )
+    hitl_history: Optional[List[InteractionHistoryEntry]] = Field(
+        None, description="History of completed HITL checkpoints"
+    )
 
     error: Optional[str] = None
 
@@ -501,7 +541,8 @@ class BatchTaskInput(BaseModel):
         description="Research query or task description (deprecated, use query instead)",
     )
     strategy: Optional[str] = Field(
-        None, description="Natural language strategy (deprecated, use research_strategy)"
+        None,
+        description="Natural language strategy (deprecated, use research_strategy)",
     )
     research_strategy: Optional[str] = Field(
         None, description="Natural language strategy to guide the research phase"
@@ -550,9 +591,6 @@ class DeepResearchBatch(BaseModel):
     """Batch of deep research tasks."""
 
     batch_id: str = Field(..., description="Unique batch ID")
-    organisation_id: Optional[str] = Field(None, description="Organization ID")
-    api_key_id: Optional[str] = Field(None, description="API key ID")
-    credit_id: Optional[str] = Field(None, description="Credit ID")
     status: BatchStatus = Field(..., description="Current batch status")
     mode: DeepResearchMode = Field(
         ..., description="Research mode (preferred field name)"
@@ -750,5 +788,3 @@ class BatchListResponse(BaseModel):
     success: bool
     batches: Optional[List[DeepResearchBatch]] = None
     error: Optional[str] = None
-
-

--- a/valyu/types/response.py
+++ b/valyu/types/response.py
@@ -24,7 +24,6 @@ class SearchResult(BaseModel):
     citation_count: Optional[int] = None
     authors: Optional[List[str]] = None
     references: Optional[str] = None
-    metadata: Optional[Dict[str, Any]] = None
 
 
 class ResultsBySource(BaseModel):


### PR DESCRIPTION
## Summary
- Remove `api_key_id`, `credit_id`, and `organisation_id` from `DeepResearchBatch` - these are internal billing/auth routing fields that must not be surfaced to SDK users
- Remove `org_id`, `source_id`, and `doc_id` from `DeepResearchSource` - internal database routing identifiers with no user-facing value
- Remove `metadata: Optional[Dict[str, Any]]` from `SearchResult` in `response.py` - catch-all dict that passed through arbitrary internal routing metadata
- Add `tests/test_sdk_api_parity.py::test_py_response_no_internal_leak` to guard against future regressions; Pydantic v2 silently drops extra fields from API responses so removing the field definitions is sufficient

---

## Task Context

| | |
|---|---|
| **Requested by** | intern-agent |
| **Run** | `0fcec868` |
| **Branch** | `intern/0fcec868` |

### Original Request
> Fix security vulnerability: Python SDK response types may expose internal routing metadata to end users.

Repo: valyu-py
File: SDK response types
Category: config
Severity: high

Test code (must pass after fix):
tests/test_sdk_api_parity.py::test_py_response_no_internal_leak

Apply the minimal fix to resolve this vulnerability. Run the test to confirm it passes.

### Attachments
None
