### PR TITLE
Add title and total_word_count to DeepResearch response types

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="valyu",
-    version="2.9.10",
+    version="2.9.11",
     author="Valyu",
     author_email="contact@valyu.ai",
     maintainer="Harvey Yorke",

--- a/valyu/__init__.py
+++ b/valyu/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.9.5"
+__version__ = "2.9.11"
 
 from .types.response import SearchResponse
 from .types.contents import (

--- a/valyu/types/deepresearch.py
+++ b/valyu/types/deepresearch.py
@@ -372,6 +372,8 @@ class DeepResearchStatusResponse(BaseModel):
     completed_at: Optional[str] = None
     output: Optional[Union[str, Dict[str, Any], Any]] = None
     output_type: Optional[Literal["markdown", "json", "toon"]] = None
+    title: Optional[str] = None
+    total_word_count: Optional[int] = None
     pdf_url: Optional[str] = None
     images: Optional[List[ImageMetadata]] = None
     deliverables: Optional[List[DeliverableResult]] = None
@@ -397,6 +399,7 @@ class DeepResearchTaskListItem(BaseModel):
     query: str
     status: DeepResearchStatus
     created_at: str
+    title: Optional[str] = None
     public: Optional[bool] = None
 
 


### PR DESCRIPTION
The data-router DeepResearch endpoint returns `title` (auto-generated report title) and `total_word_count` (total word count of the synthesised report) on every completed task, and `title` per item on the list endpoint. These were present on the wire but absent from the typed models, so Pydantic stripped them and typed Python consumers could not read them.

Changes:
- `DeepResearchStatusResponse`: add `title: Optional[str]` and `total_word_count: Optional[int]`.
- `DeepResearchTaskListItem`: add `title: Optional[str]`.

All fields default to `None`, so older server responses without them continue to parse.

Version bumped to `2.9.11`. `valyu/__init__.py` had drifted to `2.9.5` while `setup.py` (and the latest PyPI release) was at `2.9.10`; this syncs both to `2.9.11` (a patch bump from the actual current version, not from the stale `__init__.py` value).