### PR TITLE
Add historical_cache support and contents date filters

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="valyu",
-    version="2.9.11",
+    version="2.9.12",
     author="Valyu",
     author_email="contact@valyu.ai",
     maintainer="Harvey Yorke",

--- a/valyu/__init__.py
+++ b/valyu/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.9.11"
+__version__ = "2.9.12"
 
 from .types.response import SearchResponse
 from .types.contents import (

--- a/valyu/_request_builders.py
+++ b/valyu/_request_builders.py
@@ -69,6 +69,7 @@ def build_search_payload(
     url_only: bool,
     source_biases: Optional[Dict[str, int]],
     instructions: Optional[str],
+    historical_cache: Optional[bool] = None,
 ) -> Dict[str, Any]:
     payload: Dict[str, Any] = {
         "query": query,
@@ -95,6 +96,8 @@ def build_search_payload(
         payload["start_date"] = start_date
     if end_date is not None:
         payload["end_date"] = end_date
+    if historical_cache is not None:
+        payload["historical_cache"] = historical_cache
     if source_biases is not None:
         payload["source_biases"] = source_biases
     if instructions is not None:
@@ -119,6 +122,9 @@ def build_contents_payload(
     screenshot: bool,
     async_mode: bool,
     webhook_url: Optional[str],
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    historical_cache: Optional[bool] = None,
 ) -> Dict[str, Any]:
     use_async = len(urls) > 10 or async_mode
     payload: Dict[str, Any] = {"urls": urls}
@@ -136,6 +142,12 @@ def build_contents_payload(
         payload["screenshot"] = screenshot
     if webhook_url:
         payload["webhook_url"] = webhook_url
+    if start_date is not None:
+        payload["start_date"] = start_date
+    if end_date is not None:
+        payload["end_date"] = end_date
+    if historical_cache is not None:
+        payload["historical_cache"] = historical_cache
     return payload
 
 

--- a/valyu/api.py
+++ b/valyu/api.py
@@ -149,6 +149,7 @@ class Valyu:
         url_only: bool = False,
         source_biases: Optional[Dict[str, int]] = None,
         instructions: Optional[str] = None,
+        historical_cache: Optional[bool] = None,
     ) -> Optional[SearchResponse]:
         """
         Query the Valyu DeepSearch API to give your AI relevant context.
@@ -185,6 +186,9 @@ class Valyu:
                 to user intent. Acts as a system prompt for the search — e.g.
                 "Focus on oncology clinical trials from 2023 onwards". Max 500 characters.
                 Ignored when fast_mode=True.
+            historical_cache (Optional[bool]): When True and a date range (start_date and/or
+                end_date) is set, return the newest cached snapshot inside the range instead
+                of the latest crawl. No-op without a date range. Defaults to False.
 
         Returns:
             Optional[SearchResponse]: The search response.
@@ -270,6 +274,9 @@ class Valyu:
             if end_date is not None:
                 payload["end_date"] = end_date
 
+            if historical_cache is not None:
+                payload["historical_cache"] = historical_cache
+
             if source_biases is not None:
                 payload["source_biases"] = source_biases
 
@@ -336,6 +343,9 @@ class Valyu:
         wait: bool = False,
         poll_interval: int = 5,
         max_wait_time: int = 3600,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        historical_cache: Optional[bool] = None,
     ) -> Optional[
         Union[ContentsResponse, ContentsJobCreateResponse, ContentsJobStatus]
     ]:
@@ -368,6 +378,11 @@ class Valyu:
             wait (bool): When async_mode=True, poll until complete and return final results. Default: False.
             poll_interval (int): Seconds between polls when wait=True. Default: 5.
             max_wait_time (int): Max seconds to wait when wait=True. Default: 3600.
+            start_date (Optional[str]): Start date filter in YYYY-MM-DD format. Inclusive.
+            end_date (Optional[str]): End date filter in YYYY-MM-DD format. Inclusive.
+            historical_cache (Optional[bool]): When True and a date range (start_date and/or
+                end_date) is set, return the newest cached snapshot inside the range instead
+                of the latest crawl. No-op without a date range. Defaults to False.
 
         Returns:
             ContentsResponse (sync), ContentsJobCreateResponse (async, wait=False),
@@ -425,6 +440,15 @@ class Valyu:
 
             if webhook_url:
                 payload["webhook_url"] = webhook_url
+
+            if start_date is not None:
+                payload["start_date"] = start_date
+
+            if end_date is not None:
+                payload["end_date"] = end_date
+
+            if historical_cache is not None:
+                payload["historical_cache"] = historical_cache
 
             response = self._session.post(
                 f"{self.base_url}/contents",

--- a/valyu/async_api.py
+++ b/valyu/async_api.py
@@ -187,6 +187,7 @@ class AsyncValyu:
         url_only: bool = False,
         source_biases: Optional[Dict[str, int]] = None,
         instructions: Optional[str] = None,
+        historical_cache: Optional[bool] = None,
     ) -> Optional[SearchResponse]:
         """
         Async version of ``Valyu.search``. See :py:meth:`Valyu.search`
@@ -221,6 +222,7 @@ class AsyncValyu:
                 url_only=url_only,
                 source_biases=source_biases,
                 instructions=instructions,
+                historical_cache=historical_cache,
             )
 
             response = await self._post("/search", payload)
@@ -284,6 +286,9 @@ class AsyncValyu:
         wait: bool = False,
         poll_interval: int = 5,
         max_wait_time: int = 3600,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        historical_cache: Optional[bool] = None,
     ) -> Optional[Union[ContentsResponse, ContentsJobCreateResponse, ContentsJobStatus]]:
         """
         Async version of ``Valyu.contents``. Arguments and semantics
@@ -313,6 +318,9 @@ class AsyncValyu:
                 screenshot=screenshot,
                 async_mode=async_mode,
                 webhook_url=webhook_url,
+                start_date=start_date,
+                end_date=end_date,
+                historical_cache=historical_cache,
             )
 
             response = await self._post("/contents", payload)

--- a/valyu/deepresearch_client.py
+++ b/valyu/deepresearch_client.py
@@ -88,6 +88,9 @@ class DeepResearchClient:
                    - excluded_sources: List of source types to exclude
                    - start_date: Start date filter in ISO format (YYYY-MM-DD), e.g., "2024-01-01"
                    - end_date: End date filter in ISO format (YYYY-MM-DD), e.g., "2024-12-31"
+                   - historical_cache: When True and a date range is set, searches return the
+                     newest cached snapshot inside the range instead of the latest crawl.
+                     Locked for the whole research run — the agent cannot toggle it mid-research.
                    - category: Category filter for results
             urls: URLs to extract and analyze
             files: File attachments (PDFs, images)

--- a/valyu/types/deepresearch.py
+++ b/valyu/types/deepresearch.py
@@ -121,6 +121,11 @@ class SearchConfig(BaseModel):
             Format: ISO date (YYYY-MM-DD), e.g., "2024-01-01"
         end_date: Filters results to content published on or before this date.
             Format: ISO date (YYYY-MM-DD), e.g., "2024-12-31"
+        historical_cache: When True and a date range (start_date and/or end_date)
+            is set, searches return the newest cached snapshot inside the range
+            instead of the latest crawl. No-op without a date range. Locked to the
+            value passed here for the whole research run — the agent cannot
+            toggle it mid-research.
         category: Filters results by a specific category.
             Category values are source-dependent.
         country_code: ISO country code for location-filtered searches.
@@ -142,6 +147,10 @@ class SearchConfig(BaseModel):
     )
     end_date: Optional[str] = Field(
         None, description="End date filter in ISO format (YYYY-MM-DD)"
+    )
+    historical_cache: Optional[bool] = Field(
+        None,
+        description="When True and a date range is set, return the newest cached snapshot inside the range instead of the latest crawl. No-op without a date range.",
     )
     category: Optional[str] = Field(None, description="Category filter for results")
     country_code: Optional[str] = Field(


### PR DESCRIPTION
## Summary

Adds support for the new `historical_cache` parameter and extends date-range filtering to the Contents API.

### New request parameters
- **`search()` (sync + async):** new `historical_cache` param. When `True` and a date range (`start_date`/`end_date`) is set, results return the newest cached snapshot inside the range instead of the latest crawl. No-op without a date range.
- **`contents()` (sync + async):** new `start_date`, `end_date` (YYYY-MM-DD, inclusive) and `historical_cache` params. Applies to both sync and async (`async_mode=True`) jobs — same request body.
- **Deep research `SearchConfig`:** new `historical_cache` field, forwarded under the nested `search` object on task creation. Locked for the whole research run — the agent cannot toggle it mid-research.

### Response fields
No changes needed — `publication_date` already exists on `SearchResult` and `ContentsResultSuccess` and is the only date field surfaced by the API.

### Notes
- All three params are omitted from the request payload when unset (no behavior change for existing callers).
- New params appended to the end of method signatures to preserve positional-arg compatibility.
- Version bumped 2.9.11 → 2.9.12 (setup.py + `__init__.py`).

## Testing
- Verified payload builders emit `start_date`/`end_date`/`historical_cache` when set and omit them when unset.
- Verified `SearchConfig(historical_cache=True).model_dump(exclude_none=True)` serializes correctly.
- Verified sync/async client signatures import cleanly.