### PR TITLE
Add Workflows API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,56 @@ result = valyu.batch.wait_for_completion(
 )
 ```
 
+### Workflows
+
+Templated DeepResearch starting points - curated by Valyu or created by your org - with typed `{variable}` placeholders and version history.
+
+```python
+# Browse curated workflows
+catalog = valyu.workflows.list(scope="valyu", vertical="investment-banking")
+for wf in catalog.workflows:
+    print(wf.slug, "-", wf.title)
+
+# Run one as a DeepResearch task
+task = valyu.deepresearch.create(
+    workflow_id="ib-company-profile",
+    workflow_params={"company": "NVIDIA (NVDA)"},
+)
+
+result = valyu.deepresearch.wait(task.deepresearch_id)
+print(result.output)
+```
+
+Create your own:
+
+```python
+valyu.workflows.create(
+    slug="weekly-competitor-scan",
+    title="Weekly Competitor Scan",
+    version={
+        "prompt": "Summarize the week's most important developments at {company}.",
+        "strategy": "Prioritize primary sources: filings, press releases, earnings calls.",
+        "report_format": "Bullet-point briefing, grouped by theme.",
+        "variables": [{"key": "company", "label": "Company", "required": True}],
+    },
+)
+```
+
+<details>
+<summary>All Workflows methods</summary>
+
+| Method | Description |
+|---|---|
+| `list(vertical, scope, q, tags, limit, expand)` | List available workflows |
+| `get(slug, version)` | Get a workflow's full template |
+| `versions(slug)` | List a workflow's version history |
+| `preview(slug, workflow_params, workflow_version)` | Resolve the template without creating a task |
+| `create(slug, title, version, ...)` | Create an org workflow |
+| `update(slug, ..., version, set_current)` | Update metadata and/or publish a new version |
+| `delete(slug)` | Delete an org workflow |
+
+</details>
+
 ### Data Sources
 
 List available data sources programmatically.

--- a/examples/workflows_example.py
+++ b/examples/workflows_example.py
@@ -1,0 +1,78 @@
+"""
+Workflows example: browse curated workflows, preview one, run it as a
+DeepResearch task, and manage your org's own workflows.
+"""
+
+import os
+from valyu import Valyu
+
+valyu = Valyu(api_key=os.getenv("VALYU_API_KEY"))
+
+# --- Browse the curated catalog -------------------------------------------
+
+catalog = valyu.workflows.list(scope="valyu")
+print(f"{catalog.total} curated workflows. Verticals: {catalog.verticals}")
+for wf in (catalog.workflows or [])[:5]:
+    print(f"  {wf.slug} - {wf.title}")
+
+# --- Inspect one ------------------------------------------------------------
+
+detail = valyu.workflows.get("ib-company-profile")
+wf = detail.workflow
+print(f"\n{wf.title} (v{wf.version}, mode={wf.recommended_mode})")
+for var in wf.variables or []:
+    print(f"  variable: {var.key} ({'required' if var.required else 'optional'})")
+
+# --- Preview the resolved template (no task created) ------------------------
+
+preview = valyu.workflows.preview(
+    "ib-company-profile",
+    workflow_params={"company": "NVIDIA (NVDA)"},
+)
+print(f"\nResolved prompt preview: {preview.resolved.input[:200]}...")
+
+# --- Run it as a DeepResearch task ------------------------------------------
+
+task = valyu.deepresearch.create(
+    workflow_id="ib-company-profile",
+    workflow_params={"company": "NVIDIA (NVDA)"},
+)
+print(f"\nTask {task.deepresearch_id} created from {task.workflow.slug} v{task.workflow.version}")
+
+# result = valyu.deepresearch.wait(task.deepresearch_id)
+# print(result.output)
+
+# --- Manage your org's own workflows ----------------------------------------
+
+created = valyu.workflows.create(
+    slug="weekly-competitor-scan",
+    title="Weekly Competitor Scan",
+    vertical="strategy",
+    version={
+        "prompt": "Summarize the week's most important developments at {company}.",
+        "strategy": "Prioritize primary sources: filings, press releases, earnings calls.",
+        "report_format": "Bullet-point briefing, grouped by theme.",
+        "variables": [{"key": "company", "label": "Company", "required": True}],
+        "recommended_mode": "fast",
+    },
+)
+print(f"\nCreated {created.workflow.slug} v{created.workflow.version}")
+
+updated = valyu.workflows.update(
+    created.workflow.slug,
+    version={
+        "prompt": "Summarize this week's developments at {company}, with sources.",
+        "strategy": "Primary sources first; flag anything market-moving.",
+        "report_format": "Bullet-point briefing, grouped by theme.",
+        "variables": [{"key": "company", "label": "Company", "required": True}],
+        "changelog": "Require sources on every bullet",
+    },
+)
+print(f"Updated to v{updated.workflow.version}")
+
+history = valyu.workflows.versions(created.workflow.slug)
+for v in history.versions or []:
+    print(f"  v{v.version} {'(current)' if v.is_current else ''} - {v.changelog}")
+
+deleted = valyu.workflows.delete(created.workflow.slug)
+print(f"Deleted {deleted.slug} at {deleted.deleted_at}")

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="valyu",
-    version="2.9.12",
+    version="2.10.0",
     author="Valyu",
     author_email="contact@valyu.ai",
     maintainer="Harvey Yorke",

--- a/valyu/__init__.py
+++ b/valyu/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.9.12"
+__version__ = "2.10.0"
 
 from .types.response import SearchResponse
 from .types.contents import (
@@ -22,6 +22,21 @@ from .types.deepresearch import (
     Interaction,
     InteractionHistoryEntry,
     DeepResearchRespondResponse,
+)
+from .types.workflows import (
+    Workflow,
+    WorkflowVariable,
+    WorkflowVariableValidation,
+    WorkflowDeliverable,
+    WorkflowTools,
+    WorkflowVersionSummary,
+    WorkflowRunInfo,
+    ResolvedWorkflowTemplate,
+    WorkflowsListResponse,
+    WorkflowResponse,
+    WorkflowVersionsResponse,
+    WorkflowPreviewResponse,
+    WorkflowDeleteResponse,
 )
 from .api import Valyu
 from .async_api import AsyncValyu
@@ -50,6 +65,19 @@ __all__ = [
     "Interaction",
     "InteractionHistoryEntry",
     "DeepResearchRespondResponse",
+    "Workflow",
+    "WorkflowVariable",
+    "WorkflowVariableValidation",
+    "WorkflowDeliverable",
+    "WorkflowTools",
+    "WorkflowVersionSummary",
+    "WorkflowRunInfo",
+    "ResolvedWorkflowTemplate",
+    "WorkflowsListResponse",
+    "WorkflowResponse",
+    "WorkflowVersionsResponse",
+    "WorkflowPreviewResponse",
+    "WorkflowDeleteResponse",
     "Valyu",
     "AsyncValyu",
     "OpenAIProvider",

--- a/valyu/api.py
+++ b/valyu/api.py
@@ -38,6 +38,7 @@ from valyu.types.answer import (
 from valyu.validation import validate_sources, format_validation_error
 from valyu.deepresearch_client import DeepResearchClient
 from valyu.batch_client import BatchClient
+from valyu.workflows_client import WorkflowsClient
 
 
 class Valyu:
@@ -114,6 +115,9 @@ class Valyu:
 
         # Initialize Batch client
         self.batch = BatchClient(self)
+
+        # Initialize Workflows client
+        self.workflows = WorkflowsClient(self)
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/valyu/deepresearch_client.py
+++ b/valyu/deepresearch_client.py
@@ -62,6 +62,9 @@ class DeepResearchClient:
         brand_collection_id: Optional[str] = None,
         hitl: Optional[Union[HitlConfig, Dict[str, bool]]] = None,
         metadata: Optional[Dict[str, Union[str, int, bool]]] = None,
+        workflow_id: Optional[str] = None,
+        workflow_params: Optional[Dict[str, Any]] = None,
+        workflow_version: Optional[int] = None,
     ) -> DeepResearchCreateResponse:
         """
         Create a new deep research task.
@@ -118,6 +121,12 @@ class DeepResearchClient:
                 - outline_review: Review the report outline
                 Not available for batch requests.
             metadata: Custom metadata (key-value pairs)
+            workflow_id: Slug of a workflow to run (see client.workflows.list()).
+                        The workflow's template supplies the prompt, strategy,
+                        report format, deliverables, and mode. Mutually exclusive
+                        with query/input/research_strategy/report_format.
+            workflow_params: Values for the workflow's variables
+            workflow_version: Specific workflow version to run (defaults to current)
 
         Returns:
             DeepResearchCreateResponse with task ID and status
@@ -125,6 +134,64 @@ class DeepResearchClient:
         try:
             # Determine which field to use (prefer query over input)
             research_query = query if query else input
+
+            # Workflow runs: the template supplies the freeform fields
+            if workflow_id:
+                if research_query or strategy or research_strategy or report_format:
+                    return DeepResearchCreateResponse(
+                        success=False,
+                        error="workflow_id is mutually exclusive with query/input/research_strategy/report_format - the workflow template supplies those fields",
+                    )
+                payload: Dict[str, Any] = {"workflow_id": workflow_id}
+                if workflow_params is not None:
+                    payload["workflow_params"] = workflow_params
+                if workflow_version is not None:
+                    payload["workflow_version"] = workflow_version
+                # Only send mode/output_formats when explicitly set so the
+                # workflow's recommended defaults apply otherwise
+                explicit_mode = mode if mode is not None else model
+                if explicit_mode is not None:
+                    payload["mode"] = (
+                        "standard" if explicit_mode == "lite" else explicit_mode
+                    )
+                if output_formats:
+                    payload["output_formats"] = output_formats
+                if webhook_url:
+                    payload["webhook_url"] = webhook_url
+                if alert_email is not None:
+                    if isinstance(alert_email, str):
+                        payload["alert_email"] = alert_email
+                    elif isinstance(alert_email, AlertEmailConfig):
+                        payload["alert_email"] = alert_email.model_dump(
+                            exclude_none=True
+                        )
+                    else:
+                        payload["alert_email"] = alert_email
+                if metadata:
+                    payload["metadata"] = metadata
+                if tools is not None:
+                    if isinstance(tools, dict):
+                        payload["tools"] = tools
+                    else:
+                        payload["tools"] = tools.model_dump(exclude_none=True)
+
+                response = self._session.post(
+                    f"{self._base_url}/deepresearch/tasks",
+                    json=payload,
+                )
+                data = response.json()
+
+                if not response.ok:
+                    return DeepResearchCreateResponse(
+                        success=False,
+                        error=data.get(
+                            "message",
+                            data.get("error", f"HTTP Error: {response.status_code}"),
+                        ),
+                    )
+
+                data.pop("success", None)
+                return DeepResearchCreateResponse(success=True, **data)
 
             # Validation
             if not research_query or not research_query.strip():

--- a/valyu/types/deepresearch.py
+++ b/valyu/types/deepresearch.py
@@ -2,6 +2,8 @@ from pydantic import BaseModel, Field, model_validator, ConfigDict
 from typing import Optional, List, Literal, Union, Dict, Any, Callable
 from enum import Enum
 
+from valyu.types.workflows import WorkflowRunInfo
+
 
 class AlertEmailConfig(BaseModel):
     """Alert email configuration with optional custom URL."""
@@ -358,6 +360,7 @@ class DeepResearchCreateResponse(BaseModel):
     webhook_secret: Optional[str] = None
     message: Optional[str] = None
     brand_collection_id: Optional[str] = None
+    workflow: Optional[WorkflowRunInfo] = None
     error: Optional[str] = None
 
 

--- a/valyu/types/workflows.py
+++ b/valyu/types/workflows.py
@@ -1,0 +1,156 @@
+"""
+Workflow types for Valyu SDK
+
+Workflows are templated DeepResearch starting points. A workflow defines a
+prompt/strategy/report format with typed {variable} placeholders; running it
+with workflow_params expands the template into a normal DeepResearch task.
+"""
+
+from pydantic import BaseModel
+from typing import Optional, List, Literal
+
+
+WorkflowMode = Literal["fast", "standard", "heavy", "max"]
+
+WorkflowVariableType = Literal["text", "textarea", "number", "date", "enum"]
+
+
+class WorkflowVariableValidation(BaseModel):
+    """Validation rules for a workflow variable."""
+
+    min_length: Optional[int] = None
+    max_length: Optional[int] = None
+    pattern: Optional[str] = None
+    enum: Optional[List[str]] = None
+
+
+class WorkflowVariable(BaseModel):
+    """A typed {variable} placeholder in a workflow template."""
+
+    key: str
+    label: Optional[str] = None
+    type: Optional[WorkflowVariableType] = None
+    required: Optional[bool] = None
+    placeholder: Optional[str] = None
+    help: Optional[str] = None
+    examples: Optional[List[str]] = None
+    validation: Optional[WorkflowVariableValidation] = None
+
+
+class WorkflowDeliverable(BaseModel):
+    """A file deliverable the workflow generates (CSV, Excel, PowerPoint, ...)."""
+
+    type: str
+    description: Optional[str] = None
+
+
+class WorkflowTools(BaseModel):
+    """Optional tools the workflow enables for the research agent."""
+
+    code_execution: Optional[bool] = None
+    screenshots: Optional[bool] = None
+    browser_use: Optional[bool] = None
+    charts: Optional[bool] = None
+
+
+class Workflow(BaseModel):
+    """A workflow as returned by list/get endpoints."""
+
+    slug: str
+    version: Optional[int] = None
+    vertical: Optional[str] = None
+    tags: Optional[List[str]] = None
+    title: Optional[str] = None
+    subtitle: Optional[str] = None
+    description: Optional[str] = None
+    popular: Optional[bool] = None
+    recommended_mode: Optional[WorkflowMode] = None
+    estimated_time: Optional[str] = None
+    is_valyu: Optional[bool] = None
+    owner_org_id: Optional[str] = None
+    variables: Optional[List[WorkflowVariable]] = None
+    deliverables: Optional[List[WorkflowDeliverable]] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    # Template fields — present on detail responses and list with expand=True
+    prompt: Optional[str] = None
+    strategy: Optional[str] = None
+    report_format: Optional[str] = None
+    tools: Optional[WorkflowTools] = None
+    changelog: Optional[str] = None
+
+
+class WorkflowVersionSummary(BaseModel):
+    """A single entry in a workflow's version history."""
+
+    version: int
+    recommended_mode: Optional[WorkflowMode] = None
+    estimated_time: Optional[str] = None
+    changelog: Optional[str] = None
+    created_at: Optional[str] = None
+    is_current: Optional[bool] = None
+
+
+class WorkflowRunInfo(BaseModel):
+    """Workflow attribution on a DeepResearch task created from a workflow."""
+
+    slug: Optional[str] = None
+    version: Optional[int] = None
+
+
+class ResolvedWorkflowTemplate(BaseModel):
+    """The expanded template returned by preview."""
+
+    input: Optional[str] = None
+    research_strategy: Optional[str] = None
+    report_format: Optional[str] = None
+    deliverables: Optional[List[WorkflowDeliverable]] = None
+    mode: Optional[WorkflowMode] = None
+    tools: Optional[WorkflowTools] = None
+
+
+class WorkflowsListResponse(BaseModel):
+    """Response from listing workflows."""
+
+    success: bool
+    workflows: Optional[List[Workflow]] = None
+    total: Optional[int] = None
+    next_cursor: Optional[str] = None
+    verticals: Optional[List[str]] = None
+    error: Optional[str] = None
+
+
+class WorkflowResponse(BaseModel):
+    """Response from getting, creating, or updating a workflow."""
+
+    success: bool
+    workflow: Optional[Workflow] = None
+    error: Optional[str] = None
+
+
+class WorkflowVersionsResponse(BaseModel):
+    """Response from listing a workflow's version history."""
+
+    success: bool
+    slug: Optional[str] = None
+    versions: Optional[List[WorkflowVersionSummary]] = None
+    error: Optional[str] = None
+
+
+class WorkflowPreviewResponse(BaseModel):
+    """Response from previewing a workflow with params (no task created)."""
+
+    success: bool
+    workflow: Optional[WorkflowRunInfo] = None
+    resolved: Optional[ResolvedWorkflowTemplate] = None
+    estimated_credits: Optional[float] = None
+    error: Optional[str] = None
+
+
+class WorkflowDeleteResponse(BaseModel):
+    """Response from deleting a workflow."""
+
+    success: bool
+    slug: Optional[str] = None
+    deleted_at: Optional[str] = None
+    error: Optional[str] = None

--- a/valyu/workflows_client.py
+++ b/valyu/workflows_client.py
@@ -1,0 +1,357 @@
+"""
+Workflows Client for Valyu SDK
+
+Workflows are templated DeepResearch starting points — Valyu-curated or
+created by your org — with typed {variable} placeholders and version history.
+Run one by passing workflow_id (the slug) to deepresearch.create().
+"""
+
+from typing import Optional, List, Dict, Any, Literal
+from valyu.types.workflows import (
+    Workflow,
+    WorkflowDeleteResponse,
+    WorkflowPreviewResponse,
+    WorkflowResponse,
+    WorkflowsListResponse,
+    WorkflowVersionsResponse,
+)
+
+
+class WorkflowsClient:
+    """Workflows API client."""
+
+    def __init__(self, parent):
+        """Initialize with parent Valyu client."""
+        self._parent = parent
+        self._base_url = parent.base_url
+        self._headers = parent.headers
+        self._session = parent._session
+
+    @staticmethod
+    def _error_message(data: Dict[str, Any], status_code: int) -> str:
+        return (
+            data.get("message") or data.get("error") or f"HTTP Error: {status_code}"
+        )
+
+    def list(
+        self,
+        vertical: Optional[str] = None,
+        scope: Optional[Literal["valyu", "org", "all"]] = None,
+        q: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        limit: Optional[int] = None,
+        expand: Optional[bool] = None,
+    ) -> WorkflowsListResponse:
+        """
+        List workflows available to your org.
+
+        Args:
+            vertical: Filter by vertical (e.g. "finance")
+            scope: "valyu" for curated workflows only, "org" for your org's
+                   workflows only, "all" for both (default)
+            q: Free-text search over title/description
+            tags: Filter by tags
+            limit: Max results (default 50, max 100)
+            expand: Include full template fields (prompt, strategy, report_format, tools)
+
+        Returns:
+            WorkflowsListResponse with workflows, total, and available verticals
+        """
+        try:
+            params: Dict[str, Any] = {}
+            if vertical:
+                params["vertical"] = vertical
+            if scope:
+                params["scope"] = scope
+            if q:
+                params["q"] = q
+            if tags:
+                params["tags"] = ",".join(tags)
+            if limit is not None:
+                params["limit"] = limit
+            if expand:
+                params["expand"] = "true"
+
+            response = self._session.get(
+                f"{self._base_url}/workflows",
+                params=params,
+            )
+            data = response.json()
+
+            if not response.ok:
+                return WorkflowsListResponse(
+                    success=False,
+                    error=self._error_message(data, response.status_code),
+                )
+
+            return WorkflowsListResponse(success=True, **data)
+
+        except Exception as e:
+            return WorkflowsListResponse(success=False, error=str(e))
+
+    def get(
+        self,
+        slug: str,
+        version: Optional[int] = None,
+    ) -> WorkflowResponse:
+        """
+        Get a workflow's full detail, including its template.
+
+        Args:
+            slug: Workflow slug
+            version: Specific version to fetch (defaults to the current version)
+
+        Returns:
+            WorkflowResponse with the full workflow detail
+        """
+        try:
+            params: Dict[str, Any] = {}
+            if version is not None:
+                params["version"] = version
+
+            response = self._session.get(
+                f"{self._base_url}/workflows/{slug}",
+                params=params,
+            )
+            data = response.json()
+
+            if not response.ok:
+                return WorkflowResponse(
+                    success=False,
+                    error=self._error_message(data, response.status_code),
+                )
+
+            return WorkflowResponse(success=True, workflow=Workflow(**data))
+
+        except Exception as e:
+            return WorkflowResponse(success=False, error=str(e))
+
+    def versions(self, slug: str) -> WorkflowVersionsResponse:
+        """
+        List a workflow's version history.
+
+        Args:
+            slug: Workflow slug
+
+        Returns:
+            WorkflowVersionsResponse with version summaries (newest first)
+        """
+        try:
+            response = self._session.get(
+                f"{self._base_url}/workflows/{slug}/versions",
+            )
+            data = response.json()
+
+            if not response.ok:
+                return WorkflowVersionsResponse(
+                    success=False,
+                    error=self._error_message(data, response.status_code),
+                )
+
+            return WorkflowVersionsResponse(success=True, **data)
+
+        except Exception as e:
+            return WorkflowVersionsResponse(success=False, error=str(e))
+
+    def preview(
+        self,
+        slug: str,
+        workflow_params: Optional[Dict[str, Any]] = None,
+        workflow_version: Optional[int] = None,
+    ) -> WorkflowPreviewResponse:
+        """
+        Resolve a workflow's template with params without creating a task.
+
+        Useful for showing the exact prompt/strategy a run would use.
+
+        Args:
+            slug: Workflow slug
+            workflow_params: Values for the workflow's variables
+            workflow_version: Specific version to resolve (defaults to current)
+
+        Returns:
+            WorkflowPreviewResponse with the resolved template
+        """
+        try:
+            payload: Dict[str, Any] = {}
+            if workflow_params is not None:
+                payload["workflow_params"] = workflow_params
+            if workflow_version is not None:
+                payload["workflow_version"] = workflow_version
+
+            response = self._session.post(
+                f"{self._base_url}/workflows/{slug}/preview",
+                json=payload,
+            )
+            data = response.json()
+
+            if not response.ok:
+                return WorkflowPreviewResponse(
+                    success=False,
+                    error=self._error_message(data, response.status_code),
+                )
+
+            return WorkflowPreviewResponse(success=True, **data)
+
+        except Exception as e:
+            return WorkflowPreviewResponse(success=False, error=str(e))
+
+    def create(
+        self,
+        slug: str,
+        title: str,
+        version: Dict[str, Any],
+        subtitle: Optional[str] = None,
+        description: Optional[str] = None,
+        vertical: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        icon: Optional[str] = None,
+    ) -> WorkflowResponse:
+        """
+        Create a new workflow for your org.
+
+        Args:
+            slug: URL-safe identifier (lowercase letters, digits, hyphens)
+            title: Display title
+            version: Template body. Required: prompt, strategy, report_format.
+                     Optional: variables, deliverables, tools, recommended_mode,
+                     estimated_time, changelog. Template fields may reference
+                     {variables} declared in variables[].
+            subtitle: Short subtitle
+            description: Longer description
+            vertical: Vertical grouping (e.g. "finance")
+            tags: Tags for filtering
+            icon: Icon identifier
+
+        Returns:
+            WorkflowResponse with the created workflow detail
+        """
+        try:
+            payload: Dict[str, Any] = {
+                "slug": slug,
+                "title": title,
+                "version": version,
+            }
+            if subtitle is not None:
+                payload["subtitle"] = subtitle
+            if description is not None:
+                payload["description"] = description
+            if vertical is not None:
+                payload["vertical"] = vertical
+            if tags is not None:
+                payload["tags"] = tags
+            if icon is not None:
+                payload["icon"] = icon
+
+            response = self._session.post(
+                f"{self._base_url}/workflows",
+                json=payload,
+            )
+            data = response.json()
+
+            if not response.ok:
+                return WorkflowResponse(
+                    success=False,
+                    error=self._error_message(data, response.status_code),
+                )
+
+            return WorkflowResponse(success=True, workflow=Workflow(**data))
+
+        except Exception as e:
+            return WorkflowResponse(success=False, error=str(e))
+
+    def update(
+        self,
+        slug: str,
+        title: Optional[str] = None,
+        subtitle: Optional[str] = None,
+        description: Optional[str] = None,
+        vertical: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        icon: Optional[str] = None,
+        version: Optional[Dict[str, Any]] = None,
+        set_current: Optional[bool] = None,
+    ) -> WorkflowResponse:
+        """
+        Update a workflow's metadata and/or publish a new template version.
+
+        Only workflows owned by your org can be updated; Valyu-curated
+        workflows are read-only. Versions are append-only — passing a version
+        body creates the next version (changelog required).
+
+        Args:
+            slug: Workflow slug
+            title: New title
+            subtitle: New subtitle
+            description: New description
+            vertical: New vertical
+            tags: Replacement tags
+            icon: New icon
+            version: New template body (same shape as create; changelog required)
+            set_current: Whether the new version becomes current (default True)
+
+        Returns:
+            WorkflowResponse with the updated workflow detail
+        """
+        try:
+            payload: Dict[str, Any] = {}
+            if title is not None:
+                payload["title"] = title
+            if subtitle is not None:
+                payload["subtitle"] = subtitle
+            if description is not None:
+                payload["description"] = description
+            if vertical is not None:
+                payload["vertical"] = vertical
+            if tags is not None:
+                payload["tags"] = tags
+            if icon is not None:
+                payload["icon"] = icon
+            if version is not None:
+                payload["version"] = version
+            if set_current is not None:
+                payload["set_current"] = set_current
+
+            response = self._session.patch(
+                f"{self._base_url}/workflows/{slug}",
+                json=payload,
+            )
+            data = response.json()
+
+            if not response.ok:
+                return WorkflowResponse(
+                    success=False,
+                    error=self._error_message(data, response.status_code),
+                )
+
+            return WorkflowResponse(success=True, workflow=Workflow(**data))
+
+        except Exception as e:
+            return WorkflowResponse(success=False, error=str(e))
+
+    def delete(self, slug: str) -> WorkflowDeleteResponse:
+        """
+        Delete a workflow owned by your org (soft delete).
+
+        Args:
+            slug: Workflow slug
+
+        Returns:
+            WorkflowDeleteResponse with the deletion timestamp
+        """
+        try:
+            response = self._session.delete(
+                f"{self._base_url}/workflows/{slug}",
+            )
+            data = response.json()
+
+            if not response.ok:
+                return WorkflowDeleteResponse(
+                    success=False,
+                    error=self._error_message(data, response.status_code),
+                )
+
+            return WorkflowDeleteResponse(success=True, **data)
+
+        except Exception as e:
+            return WorkflowDeleteResponse(success=False, error=str(e))


### PR DESCRIPTION
## Summary

Adds full support for the Workflows API: templated DeepResearch starting points with typed `{variable}` placeholders and version history.

### New: `valyu.workflows` client
- `list(vertical, scope, q, tags, limit, expand)` - browse Valyu-curated and org workflows
- `get(slug, version)` - full workflow detail including the template
- `versions(slug)` - version history
- `preview(slug, workflow_params, workflow_version)` - resolve the template without creating a task
- `create(...)` / `update(...)` / `delete(slug)` - org workflow CRUD (versions are append-only)

### DeepResearch integration
- `deepresearch.create()` accepts `workflow_id`, `workflow_params`, `workflow_version` to run a workflow as a research task. Mutually exclusive with `query`/`input`/`research_strategy`/`report_format` (validated client-side with a clear error). Mode and output formats are only sent when explicitly set so the workflow's recommended defaults apply.
- `DeepResearchCreateResponse` now includes `workflow: {slug, version}` attribution.

### Other
- Pydantic models for all workflow request/response shapes, exported from the package root
- `examples/workflows_example.py`
- README section with usage and method table
- Version bump to 2.10.0

## Testing

Verified every method against the live API: list (all filters + expand), get (current + pinned version + 404), versions, preview (resolution + missing-param validation error), org create -> metadata update -> new version -> version history -> delete, 403 on editing curated workflows, client-side mutual-exclusion error, and a real task created via `workflow_id` with correct workflow attribution (then cancelled). All passed.