### PR TITLE
Harden Deep Research status polling against transient drops

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="valyu",
-    version="2.10.0",
+    version="2.11.0",
     author="Valyu",
     author_email="contact@valyu.ai",
     maintainer="Harvey Yorke",

--- a/valyu/deepresearch_client.py
+++ b/valyu/deepresearch_client.py
@@ -3,6 +3,7 @@ DeepResearch Client for Valyu SDK
 """
 
 import time
+import random
 import requests
 from typing import Optional, List, Literal, Union, Dict, Any, Callable
 from valyu.types.deepresearch import (
@@ -25,6 +26,12 @@ from valyu.types.deepresearch import (
     DeepResearchTogglePublicResponse,
     DeepResearchRespondResponse,
 )
+
+
+# HTTP status codes that indicate a transient gateway/server/rate-limit
+# condition rather than a definitive answer about the task. The status
+# endpoint is idempotent and meant to be polled, so these are retried.
+_TRANSIENT_STATUS_CODES = frozenset({408, 429, 500, 502, 503, 504})
 
 
 class DeepResearchClient:
@@ -335,37 +342,86 @@ class DeepResearchClient:
                 error=str(e),
             )
 
-    def status(self, task_id: str) -> DeepResearchStatusResponse:
+    def status(self, task_id: str, max_attempts: int = 5) -> DeepResearchStatusResponse:
         """
         Get the status of a deep research task.
 
+        The status endpoint is idempotent and built to be polled, so transient
+        failures are retried with exponential backoff + jitter instead of being
+        reported as task failures. Treated as transient (and retried):
+        connection errors and timeouts, HTTP 429/5xx (e.g. an ALB 502 gateway
+        page), and non-JSON or empty response bodies. Only a definitive error
+        response (a 4xx other than 429 carrying a JSON error) is returned as a
+        failure.
+
+        If the endpoint stays unreachable across every attempt, the result has
+        ``success=False`` and ``unreachable=True`` — this means "couldn't read
+        status", which is retryable and distinct from "the task failed". The
+        completed report may still be retrievable.
+
         Args:
             task_id: Task ID to check
+            max_attempts: Attempts before giving up as unreachable (default: 5)
 
         Returns:
             DeepResearchStatusResponse with current status
         """
-        try:
-            response = self._session.get(
-                f"{self._base_url}/deepresearch/tasks/{task_id}/status",
-            )
+        url = f"{self._base_url}/deepresearch/tasks/{task_id}/status"
+        last_error = "status endpoint unreachable"
 
-            data = response.json()
+        for attempt in range(max_attempts):
+            transient = True
+            try:
+                response = self._session.get(url)
 
-            if not response.ok:
-                return DeepResearchStatusResponse(
-                    success=False,
-                    error=data.get("error", f"HTTP Error: {response.status_code}"),
-                )
+                if response.status_code in _TRANSIENT_STATUS_CODES:
+                    # Gateway/rate-limit/server blip — the task is unaffected.
+                    last_error = f"HTTP {response.status_code}"
+                else:
+                    # An HTML 502 page or an empty body is a gateway artifact,
+                    # not the task's real status. Guard before parsing so we
+                    # never conflate a bad body with a failed task.
+                    content_type = response.headers.get("content-type", "")
+                    if (
+                        "application/json" not in content_type.lower()
+                        or not response.text.strip()
+                    ):
+                        last_error = (
+                            f"non-JSON/empty status response (HTTP "
+                            f"{response.status_code}, content-type: "
+                            f"{content_type or 'none'})"
+                        )
+                    else:
+                        data = response.json()
+                        if not response.ok:
+                            # Definitive error response (e.g. 4xx) — terminal.
+                            return DeepResearchStatusResponse(
+                                success=False,
+                                error=data.get(
+                                    "error", f"HTTP Error: {response.status_code}"
+                                ),
+                            )
+                        data.pop("success", None)
+                        return DeepResearchStatusResponse(success=True, **data)
 
-            data.pop("success", None)
-            return DeepResearchStatusResponse(success=True, **data)
+            except (requests.exceptions.RequestException, ValueError) as e:
+                # Connection errors, timeouts, and JSON decode errors are all
+                # transient drops of a single poll.
+                last_error = str(e) or e.__class__.__name__
 
-        except Exception as e:
-            return DeepResearchStatusResponse(
-                success=False,
-                error=str(e),
-            )
+            if transient and attempt < max_attempts - 1:
+                # Exponential backoff capped at 30s, with jitter to avoid
+                # synchronised retries hammering a recovering gateway.
+                time.sleep(min(2 ** attempt, 30) + random.random())
+
+        return DeepResearchStatusResponse(
+            success=False,
+            unreachable=True,
+            error=(
+                f"Status endpoint unreachable after {max_attempts} attempts: "
+                f"{last_error}"
+            ),
+        )
 
     def wait(
         self,
@@ -392,8 +448,10 @@ class DeepResearchClient:
             Final task status
 
         Raises:
-            TimeoutError: If max_wait_time is exceeded
-            ValueError: If task fails or is cancelled
+            TimeoutError: If max_wait_time is exceeded (including while the
+                status endpoint stays unreachable)
+            ValueError: If task fails or is cancelled, or status returns a
+                definitive (non-transient) error
         """
         start_time = time.time()
 
@@ -401,6 +459,18 @@ class DeepResearchClient:
             status = self.status(task_id)
 
             if not status.success:
+                # A transiently unreachable status endpoint is not a task
+                # failure — keep polling within max_wait_time, since the task
+                # may well be running (or already completed) server-side.
+                if status.unreachable:
+                    elapsed = time.time() - start_time
+                    if elapsed > max_wait_time:
+                        raise TimeoutError(
+                            f"Status endpoint unreachable for {max_wait_time} "
+                            f"seconds: {status.error}"
+                        )
+                    time.sleep(poll_interval)
+                    continue
                 raise ValueError(f"Failed to get status: {status.error}")
 
             # Notify progress callback

--- a/valyu/types/deepresearch.py
+++ b/valyu/types/deepresearch.py
@@ -402,6 +402,15 @@ class DeepResearchStatusResponse(BaseModel):
     hitl_history: Optional[List[InteractionHistoryEntry]] = Field(None, description="History of completed HITL checkpoints")
 
     error: Optional[str] = None
+    unreachable: Optional[bool] = Field(
+        None,
+        description=(
+            "True when success=False because the status endpoint could not be "
+            "reached after retries (transient gateway/network failure). This is "
+            "retryable and distinct from a failed task — the report may still be "
+            "available."
+        ),
+    )
 
 
 class DeepResearchTaskListItem(BaseModel):


### PR DESCRIPTION
## Problem

Customers polling `GET /v1/deepresearch/tasks/:id/status` intermittently get a non-JSON response (an HTML 502 gateway page or an empty body) and the SDK raises `Failed to get status: Expecting value: line 1 column 1 (char 0)` — `status()` called `response.json()` on a body that isn't JSON. The poll loop then treated this as a **terminal task failure** and abandoned the task, even though the research completed successfully server-side. One customer saw ~20–30% of successful tasks reported as failed this way.

Root cause is a server-side ALB↔Node keep-alive race (fixed separately), but the SDK shouldn't be fragile to it regardless — gateway blips, deploy-time deregistration, 429/5xx, and network jitter can all drop a single poll, and the status endpoint is idempotent and meant to be polled.

## Change

Hardening lives in the low-level `status()` so **every** caller benefits — the SDK's own `wait()`/`stream()` loops *and* hand-rolled customer poll loops.

- Guard on status code and `content-type` **before** parsing — no more blind `.json()`.
- Treat as **transient** and retry with exponential backoff + jitter (5 attempts by default): HTTP 408/429/5xx, connection errors/timeouts, and non-JSON/empty bodies.
- Only **fail** on a definitive terminal signal: a 4xx (non-429) error response, or a payload reporting `status: "failed"`. No retry delay added to genuine failures.
- If the endpoint stays unreachable across all attempts, the result carries the new optional `unreachable=true` field — distinguishing "couldn't read status" (retryable; the report may still be available) from "the task failed".
- `wait()` rides out `unreachable` periods up to `max_wait_time` instead of failing on one bad poll.

## Acceptance

A single 502/empty/5xx status response no longer fails an otherwise-running/completed task — it retries and continues. Verified: 502-blip→completed, empty-body→running, persistent-502→`unreachable` (not failed), 404→immediate fail (no retry), connection-error→completed.

## Compatibility

Backward compatible — only an optional `max_attempts` param and an optional `unreachable` response field added; success and genuine-failure paths unchanged. Minor version bump (`2.10.0 → 2.11.0`) for the additive API surface.