### PR TITLE
Align research_strategy/report_format length guard with server 400

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="valyu",
-    version="2.11.0",
+    version="2.11.1",
     author="Valyu",
     author_email="contact@valyu.ai",
     maintainer="Harvey Yorke",

--- a/tests/test_deepresearch_length_cap.py
+++ b/tests/test_deepresearch_length_cap.py
@@ -1,0 +1,122 @@
+"""
+Tests for the client-side research_strategy/report_format combined length cap
+enforced by DeepResearchClient.create().
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from valyu.deepresearch_client import (
+    DeepResearchClient,
+    MAX_STRATEGY_REPORT_FORMAT_COMBINED_LENGTH,
+)
+
+
+def _make_client():
+    """Build a DeepResearchClient with a stubbed session so no network is hit."""
+    session = MagicMock()
+    parent = SimpleNamespace(
+        base_url="https://api.example.com",
+        headers={},
+        _session=session,
+    )
+    return DeepResearchClient(parent), session
+
+
+def _ok_response():
+    """A fake requests-style response representing a successful create."""
+    response = MagicMock()
+    response.ok = True
+    response.status_code = 200
+    response.json.return_value = {
+        "success": True,
+        "deepresearch_id": "dr_123",
+        "status": "queued",
+    }
+    return response
+
+
+class CombinedLengthCapTest(unittest.TestCase):
+    def test_exactly_limit_passes_guard(self):
+        """A combined length of exactly the limit must NOT short-circuit."""
+        client, session = _make_client()
+        session.post.return_value = _ok_response()
+
+        half = MAX_STRATEGY_REPORT_FORMAT_COMBINED_LENGTH // 2
+        research_strategy = "a" * half
+        report_format = "b" * (MAX_STRATEGY_REPORT_FORMAT_COMBINED_LENGTH - half)
+        self.assertEqual(
+            len(research_strategy) + len(report_format),
+            MAX_STRATEGY_REPORT_FORMAT_COMBINED_LENGTH,
+        )
+
+        result = client.create(
+            query="test query",
+            research_strategy=research_strategy,
+            report_format=report_format,
+        )
+
+        # Guard did not fire: it reached the network layer and succeeded.
+        session.post.assert_called_once()
+        self.assertTrue(result.success)
+        self.assertIsNone(result.error)
+
+    def test_one_over_limit_returns_error(self):
+        """One character over the limit returns the server-identical 400 error."""
+        client, session = _make_client()
+
+        combined = MAX_STRATEGY_REPORT_FORMAT_COMBINED_LENGTH + 1
+        research_strategy = "a" * combined
+
+        result = client.create(
+            query="test query",
+            research_strategy=research_strategy,
+        )
+
+        # Guard fired before any network call.
+        session.post.assert_not_called()
+        self.assertFalse(result.success)
+        self.assertEqual(
+            result.error,
+            f"research_strategy and report_format combined length ({combined}) "
+            f"exceeds 15,000 character limit",
+        )
+
+    def test_legacy_strategy_alias_counts(self):
+        """The legacy `strategy` alias is counted when research_strategy is unset."""
+        client, session = _make_client()
+
+        combined = MAX_STRATEGY_REPORT_FORMAT_COMBINED_LENGTH + 1
+        result = client.create(
+            query="test query",
+            strategy="a" * combined,
+        )
+
+        session.post.assert_not_called()
+        self.assertFalse(result.success)
+        self.assertEqual(
+            result.error,
+            f"research_strategy and report_format combined length ({combined}) "
+            f"exceeds 15,000 character limit",
+        )
+
+    def test_research_strategy_wins_over_legacy_alias(self):
+        """When both are sent, research_strategy takes precedence (server parity)."""
+        client, session = _make_client()
+        session.post.return_value = _ok_response()
+
+        # A short research_strategy wins over a huge legacy strategy, so the
+        # combined length is small and the guard does not fire.
+        result = client.create(
+            query="test query",
+            research_strategy="short",
+            strategy="a" * (MAX_STRATEGY_REPORT_FORMAT_COMBINED_LENGTH + 1),
+        )
+
+        session.post.assert_called_once()
+        self.assertTrue(result.success)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/valyu/deepresearch_client.py
+++ b/valyu/deepresearch_client.py
@@ -28,6 +28,13 @@ from valyu.types.deepresearch import (
 )
 
 
+# Hard cap enforced by the create endpoint: the combined character length of
+# research_strategy (or its legacy alias strategy) and report_format must not
+# exceed this. The server rejects anything strictly greater with an HTTP 400,
+# so exactly this value still passes.
+MAX_STRATEGY_REPORT_FORMAT_COMBINED_LENGTH = 15000
+
+
 # HTTP status codes that indicate a transient gateway/server/rate-limit
 # condition rather than a definitive answer about the task. The status
 # endpoint is idempotent and meant to be polled, so these are retried.
@@ -86,10 +93,15 @@ class DeepResearchClient:
             output_formats: Output formats - ["markdown"], ["markdown", "pdf"], or a JSON schema object.
                            When using a JSON schema, the output will be structured JSON instead of markdown.
                            Cannot mix JSON schema with markdown/pdf - use one or the other.
-            strategy: Natural language strategy for the research (deprecated, use research_strategy instead)
-            research_strategy: Natural language strategy to guide the research phase (methodology, focus areas, depth)
+            strategy: Natural language strategy for the research (deprecated, use research_strategy instead).
+                Counts toward the combined research_strategy/report_format length cap below.
+            research_strategy: Natural language strategy to guide the research phase (methodology, focus areas, depth).
+                Combined character length of research_strategy (or its legacy alias strategy) and report_format
+                must not exceed 15,000 characters; exceeding this returns a 400-equivalent error.
             report_format: Natural language instructions for the output format (structure, tone, length, style).
                 Has highest priority — overrides default formatting.
+                Combined character length of research_strategy (or its legacy alias strategy) and report_format
+                must not exceed 15,000 characters; exceeding this returns a 400-equivalent error.
             search: Search configuration (type, sources, dates, category).
                    Can be a SearchConfig object or dict with search parameters:
                    - search_type: "all" (default), "web", or "proprietary"
@@ -139,6 +151,25 @@ class DeepResearchClient:
             DeepResearchCreateResponse with task ID and status
         """
         try:
+            # Client-side guard mirroring the server's hard cap so callers get
+            # an identical error without a round-trip. The server reads
+            # research_strategy ?? strategy, so mirror that precedence here and
+            # reuse the API's exact 400 message.
+            effective_strategy = (
+                research_strategy if research_strategy is not None else strategy
+            )
+            combined_strategy_format_length = len(effective_strategy or "") + len(
+                report_format or ""
+            )
+            if (
+                combined_strategy_format_length
+                > MAX_STRATEGY_REPORT_FORMAT_COMBINED_LENGTH
+            ):
+                return DeepResearchCreateResponse(
+                    success=False,
+                    error=f"research_strategy and report_format combined length ({combined_strategy_format_length}) exceeds 15,000 character limit",
+                )
+
             # Determine which field to use (prefer query over input)
             research_query = query if query else input
 
@@ -211,14 +242,6 @@ class DeepResearchClient:
                 return DeepResearchCreateResponse(
                     success=False,
                     error=f"query exceeds 25,000 character limit ({len(research_query)} characters)",
-                )
-
-            strategy_len = len(research_strategy or "")
-            format_len = len(report_format or "")
-            if strategy_len + format_len > 15000:
-                return DeepResearchCreateResponse(
-                    success=False,
-                    error=f"Combined length of research_strategy ({strategy_len}) and report_format ({format_len}) exceeds 15,000 character limit",
                 )
 
             if files:

--- a/valyu/types/deepresearch.py
+++ b/valyu/types/deepresearch.py
@@ -119,15 +119,22 @@ class SearchConfig(BaseModel):
         excluded_sources: Excludes specific source types from search results.
             Uses the same source type values as included_sources.
             Cannot be used simultaneously with included_sources.
-        start_date: Filters results to content published on or after this date.
-            Format: ISO date (YYYY-MM-DD), e.g., "2024-01-01"
-        end_date: Filters results to content published on or before this date.
-            Format: ISO date (YYYY-MM-DD), e.g., "2024-12-31"
+        start_date: Inclusive lower bound on content date. Accepts a bare date
+            (YYYY-MM-DD, day granularity, e.g. "2026-01-01") or a full ISO-8601
+            datetime (YYYY-MM-DDTHH:MM[:SS[.sss]][Z|±HH:MM], e.g.
+            "2026-01-01T00:00:00Z"; a space separator is also accepted). A value
+            with any time component requires historical_cache=True and is
+            otherwise rejected with HTTP 400 — use a bare date for standard search.
+        end_date: Inclusive upper bound on content date. Same formats and
+            historical_cache=True requirement for sub-day timestamps as start_date.
         historical_cache: When True and a date range (start_date and/or end_date)
             is set, searches return the newest cached snapshot inside the range
-            instead of the latest crawl. No-op without a date range. Locked to the
-            value passed here for the whole research run — the agent cannot
-            toggle it mid-research.
+            instead of the latest crawl — a leak-safe "as-of" backtest (snapshot
+            metadata only on a hit; the URL is dropped on a miss). Also gates
+            sub-day precision: required to pass any timestamped start_date/end_date
+            (a time component without it is rejected with HTTP 400). No-op without
+            a date range. User-set only and locked for the whole research run —
+            the agent cannot toggle it mid-research.
         category: Filters results by a specific category.
             Category values are source-dependent.
         country_code: ISO country code for location-filtered searches.
@@ -145,14 +152,16 @@ class SearchConfig(BaseModel):
         None, description="Source types to exclude from search"
     )
     start_date: Optional[str] = Field(
-        None, description="Start date filter in ISO format (YYYY-MM-DD)"
+        None,
+        description="Inclusive start bound. Bare date (YYYY-MM-DD) or full ISO-8601 datetime; a datetime with any time component requires historical_cache=True, else HTTP 400.",
     )
     end_date: Optional[str] = Field(
-        None, description="End date filter in ISO format (YYYY-MM-DD)"
+        None,
+        description="Inclusive end bound. Bare date (YYYY-MM-DD) or full ISO-8601 datetime; a datetime with any time component requires historical_cache=True, else HTTP 400.",
     )
     historical_cache: Optional[bool] = Field(
         None,
-        description="When True and a date range is set, return the newest cached snapshot inside the range instead of the latest crawl. No-op without a date range.",
+        description="When True and a date range is set, return the newest cached snapshot inside the range (leak-safe as-of backtest) instead of the latest crawl. Also required to pass any sub-day timestamp on start_date/end_date. No-op without a date range. User-set only.",
     )
     category: Optional[str] = Field(None, description="Category filter for results")
     country_code: Optional[str] = Field(


### PR DESCRIPTION
## What

The DeepResearch create endpoint enforces a hard cap: the combined character length of `research_strategy` (or its legacy alias `strategy`) and `report_format` must not exceed **15,000 characters**. Over the limit, the server returns HTTP 400 with error `research_strategy and report_format combined length (N) exceeds 15,000 character limit`. Boundary is inclusive — exactly 15000 passes, 15001 is the first failure. `query` and research content do **not** count.

## Why

A pre-existing client-side guard in `create()` only counted `research_strategy` and ignored the legacy `strategy` alias, and emitted a different message than the server. A caller using the old `strategy` field slipped past the client check and hit the server 400 directly.

## Change

- Replace the old guard with a single check that mirrors the server's `research_strategy ?? strategy` precedence and returns the **exact** server 400 string (so client- and server-side rejections are identical). Still returns an error-shaped response — does not raise — matching the method's existing contract.
- Update `research_strategy` / `report_format` / `strategy` docstrings.
- Add unit tests (15000 passes the guard, 15001 rejects, alias counts, research_strategy wins over alias).
- Patch bump 2.11.0 → 2.11.1.

Batch path left untouched (cap only confirmed for single create).


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/valyuAI/codesmith/valyu-py/pr/127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786631887&installation_id=141286747&pr_number=127&repository=valyuAI%2Fvalyu-py&return_to=https%3A%2F%2Fgithub.com%2FvalyuAI%2Fvalyu-py%2Fpull%2F127&signature=38a9e67c84d68a42425ad7790f629e28f60f46b20affd993ac8adc7c5cf2dcc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
