### PR TITLE
Workflows API: forward per-run options and surface validation detail

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,36 @@
 # setup.py
 
+import pathlib
+import re
+
 from setuptools import setup, find_packages
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
+
+def read_version() -> str:
+    """
+    Single-source the version from valyu/__init__.py.
+
+    __version__ is sent on every request as User-Agent and X-Valyu-SDK-Version,
+    so a version declared in two places will eventually disagree and misreport
+    which SDK build a request came from. Read it, don't repeat it.
+    """
+    init = pathlib.Path(__file__).parent / "valyu" / "__init__.py"
+    match = re.search(
+        r'^__version__\s*=\s*["\']([^"\']+)["\']',
+        init.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    if not match:
+        raise RuntimeError("Could not find __version__ in valyu/__init__.py")
+    return match.group(1)
+
+
 setup(
     name="valyu",
-    version="2.11.1",
+    version=read_version(),
     author="Valyu",
     author_email="contact@valyu.ai",
     maintainer="Harvey Yorke",

--- a/tests/test_deepresearch_workflow_payload.py
+++ b/tests/test_deepresearch_workflow_payload.py
@@ -1,0 +1,166 @@
+"""
+Tests that a workflow run sends the same per-run options a freeform run does.
+
+The workflow template supplies the freeform fields (prompt, strategy, report
+format). Everything else — deliverables, search, previous_reports, hitl, urls,
+files, mcp_servers, brand_collection_id — is a per-run concern the API accepts
+either way, so it must reach the wire rather than being dropped when
+workflow_id is set.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from valyu.deepresearch_client import DeepResearchClient
+from valyu.types.deepresearch import Deliverable, HitlConfig, SearchConfig
+
+# Per-run options that must survive on both code paths.
+SHARED_OPTIONS = dict(
+    deliverables=["xlsx"],
+    search={"start_date": "2019-01-01"},
+    previous_reports=["dr_a", "dr_b"],
+    hitl={"plan_review": True},
+    urls=["https://example.com"],
+    mcp_servers=[{"name": "srv", "url": "https://mcp.example.com"}],
+    brand_collection_id="brand_1",
+    metadata={"deal": "project-frost"},
+    tools={"code_execution": {"enabled": True, "max_calls": 5}},
+    webhook_url="https://example.com/hook",
+    alert_email="analyst@example.com",
+)
+
+
+def _make_client():
+    """Build a DeepResearchClient with a stubbed session so no network is hit."""
+    session = MagicMock()
+    response = MagicMock()
+    response.ok = True
+    response.status_code = 200
+    response.json.return_value = {
+        "success": True,
+        "deepresearch_id": "dr_123",
+        "status": "queued",
+    }
+    session.post.return_value = response
+    parent = SimpleNamespace(
+        base_url="https://api.example.com",
+        headers={},
+        _session=session,
+    )
+    return DeepResearchClient(parent), session
+
+
+def _sent_payload(session):
+    """The JSON body handed to session.post."""
+    return session.post.call_args.kwargs["json"]
+
+
+class WorkflowPayloadTest(unittest.TestCase):
+    def test_workflow_run_forwards_shared_options(self):
+        """Every per-run option reaches the wire on a workflow run."""
+        client, session = _make_client()
+
+        result = client.create(
+            workflow_id="ib-comps-analysis",
+            workflow_params={"target": "Datadog (DDOG)"},
+            **SHARED_OPTIONS,
+        )
+
+        self.assertTrue(result.success)
+        payload = _sent_payload(session)
+
+        self.assertEqual(payload["workflow_id"], "ib-comps-analysis")
+        self.assertEqual(payload["workflow_params"], {"target": "Datadog (DDOG)"})
+        for key, value in SHARED_OPTIONS.items():
+            self.assertIn(key, payload, f"{key} was dropped from the workflow payload")
+            self.assertEqual(payload[key], value)
+
+    def test_workflow_and_freeform_agree_on_shared_options(self):
+        """The two code paths serialise per-run options identically."""
+        workflow_client, workflow_session = _make_client()
+        workflow_client.create(
+            workflow_id="ib-comps-analysis",
+            workflow_params={"target": "Datadog (DDOG)"},
+            **SHARED_OPTIONS,
+        )
+
+        freeform_client, freeform_session = _make_client()
+        freeform_client.create(query="a freeform query", **SHARED_OPTIONS)
+
+        workflow_payload = _sent_payload(workflow_session)
+        freeform_payload = _sent_payload(freeform_session)
+
+        for key in SHARED_OPTIONS:
+            self.assertEqual(
+                workflow_payload.get(key),
+                freeform_payload.get(key),
+                f"{key} serialises differently on the two paths",
+            )
+
+    def test_workflow_run_omits_unset_options(self):
+        """A bare workflow run stays minimal so template defaults apply."""
+        client, session = _make_client()
+
+        client.create(
+            workflow_id="ib-company-profile",
+            workflow_params={"company": "NVIDIA (NVDA)"},
+        )
+
+        self.assertEqual(
+            _sent_payload(session),
+            {
+                "workflow_id": "ib-company-profile",
+                "workflow_params": {"company": "NVIDIA (NVDA)"},
+            },
+        )
+
+    def test_workflow_run_serialises_pydantic_models(self):
+        """Typed config objects are dumped, not passed through as models."""
+        client, session = _make_client()
+
+        client.create(
+            workflow_id="ib-comps-analysis",
+            workflow_params={"target": "Datadog (DDOG)"},
+            search=SearchConfig(start_date="2019-01-01"),
+            deliverables=[Deliverable(type="xlsx", description="Trading comps")],
+            hitl=HitlConfig(plan_review=True),
+        )
+
+        payload = _sent_payload(session)
+        self.assertEqual(payload["search"], {"start_date": "2019-01-01"})
+        self.assertEqual(payload["deliverables"][0]["type"], "xlsx")
+        self.assertEqual(payload["deliverables"][0]["description"], "Trading comps")
+        self.assertEqual(payload["hitl"], {"plan_review": True})
+
+    def test_workflow_run_rejects_oversized_file_context(self):
+        """The files[].context cap applies to workflow runs too."""
+        client, session = _make_client()
+
+        result = client.create(
+            workflow_id="ib-company-profile",
+            workflow_params={"company": "NVIDIA (NVDA)"},
+            files=[{"url": "https://example.com/a.pdf", "context": "x" * 10001}],
+        )
+
+        session.post.assert_not_called()
+        self.assertFalse(result.success)
+        self.assertIn("files[0].context exceeds 10,000 character limit", result.error)
+
+    def test_workflow_run_still_rejects_freeform_fields(self):
+        """workflow_id stays mutually exclusive with the template-supplied fields."""
+        client, session = _make_client()
+
+        result = client.create(
+            workflow_id="ib-company-profile",
+            workflow_params={"company": "NVIDIA (NVDA)"},
+            query="a freeform query",
+        )
+
+        session.post.assert_not_called()
+        self.assertFalse(result.success)
+        self.assertIn("mutually exclusive", result.error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_error_message.py
+++ b/tests/test_error_message.py
@@ -8,6 +8,8 @@ was wrong or what the API expected instead.
 
 import unittest
 
+import valyu
+from valyu import Valyu
 from valyu._errors import error_message
 
 
@@ -65,6 +67,17 @@ class ErrorMessageTest(unittest.TestCase):
 
     def test_non_dict_body(self):
         self.assertEqual(error_message("gateway timeout", 504), "HTTP Error: 504")
+
+
+class VersionHeaderTest(unittest.TestCase):
+    def test_headers_report_package_version(self):
+        """__version__ is what identifies the build to the API on every request."""
+        client = Valyu(api_key="val_test")
+
+        self.assertEqual(client.headers["X-Valyu-SDK-Version"], valyu.__version__)
+        self.assertTrue(
+            client.headers["User-Agent"].startswith(f"valyu-py/{valyu.__version__} ")
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_error_message.py
+++ b/tests/test_error_message.py
@@ -1,0 +1,71 @@
+"""
+Tests that API validation detail survives into SDK error strings.
+
+The API returns an `errors` array naming each offending field. Keeping only the
+summary ("2 validation errors") leaves a caller unable to tell which parameter
+was wrong or what the API expected instead.
+"""
+
+import unittest
+
+from valyu._errors import error_message
+
+
+class ErrorMessageTest(unittest.TestCase):
+    def test_validation_errors_are_appended(self):
+        message = error_message(
+            {
+                "error": "validation_failed",
+                "message": "2 validation errors",
+                "errors": [
+                    {
+                        "code": "unknown_param",
+                        "key": "company",
+                        "message": 'Unknown parameter "company"',
+                    },
+                    {
+                        "code": "missing_param",
+                        "key": "target",
+                        "message": 'Required parameter "target" is missing',
+                    },
+                ],
+            },
+            400,
+        )
+
+        self.assertIn("2 validation errors", message)
+        self.assertIn('Unknown parameter "company"', message)
+        self.assertIn('Required parameter "target" is missing', message)
+
+    def test_key_is_prefixed_when_not_already_named(self):
+        message = error_message(
+            {
+                "message": "1 validation error",
+                "errors": [{"code": "missing_param", "key": "sector"}],
+            },
+            400,
+        )
+
+        self.assertIn("sector: missing_param", message)
+
+    def test_falls_back_to_summary_without_errors_array(self):
+        self.assertEqual(
+            error_message({"message": "Insufficient credits"}, 402),
+            "Insufficient credits",
+        )
+
+    def test_falls_back_to_error_field(self):
+        self.assertEqual(
+            error_message({"error": "workflow_not_found"}, 404),
+            "workflow_not_found",
+        )
+
+    def test_falls_back_to_status_code(self):
+        self.assertEqual(error_message({}, 500), "HTTP Error: 500")
+
+    def test_non_dict_body(self):
+        self.assertEqual(error_message("gateway timeout", 504), "HTTP Error: 504")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/valyu/__init__.py
+++ b/valyu/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.10.0"
+__version__ = "2.12.0"
 
 from .types.response import SearchResponse
 from .types.contents import (

--- a/valyu/_errors.py
+++ b/valyu/_errors.py
@@ -1,0 +1,44 @@
+"""
+Shared error-message formatting for Valyu API responses.
+"""
+
+from typing import Any, Dict
+
+
+def error_message(data: Dict[str, Any], status_code: int) -> str:
+    """
+    Build a human-readable error string from an API error body.
+
+    Validation failures carry an `errors` array naming each offending field, so
+    fold those into the message. Without them a caller only sees a summary like
+    "2 validation errors", which says nothing about which parameter was wrong or
+    what the API expected instead.
+
+    Args:
+        data: Parsed JSON error body
+        status_code: HTTP status code, used when the body carries no message
+
+    Returns:
+        The error message, suffixed with per-field detail when available
+    """
+    if not isinstance(data, dict):
+        return f"HTTP Error: {status_code}"
+
+    summary = data.get("message") or data.get("error") or f"HTTP Error: {status_code}"
+
+    details = []
+    for item in data.get("errors") or []:
+        if isinstance(item, dict):
+            detail = item.get("message") or item.get("code")
+            key = item.get("key")
+            if detail and key and key not in str(detail):
+                detail = f"{key}: {detail}"
+        else:
+            detail = item
+        if detail:
+            details.append(str(detail))
+
+    if not details:
+        return str(summary)
+
+    return f"{summary}: {'; '.join(details)}"

--- a/valyu/deepresearch_client.py
+++ b/valyu/deepresearch_client.py
@@ -6,6 +6,7 @@ import time
 import random
 import requests
 from typing import Optional, List, Literal, Union, Dict, Any, Callable
+from valyu._errors import error_message as _error_message
 from valyu.types.deepresearch import (
     AlertEmailConfig,
     DeepResearchMode,
@@ -50,6 +51,89 @@ class DeepResearchClient:
         self._base_url = parent.base_url
         self._headers = parent.headers
         self._session = parent._session
+
+    @staticmethod
+    def _build_shared_fields(
+        search=None,
+        urls=None,
+        files=None,
+        deliverables=None,
+        mcp_servers=None,
+        previous_reports=None,
+        webhook_url=None,
+        alert_email=None,
+        brand_collection_id=None,
+        metadata=None,
+        hitl=None,
+        tools=None,
+        code_execution=None,
+    ) -> Dict[str, Any]:
+        """
+        Build the request fields that are valid for both freeform and workflow runs.
+
+        Workflow templates supply the freeform fields (prompt, strategy, report
+        format) but everything below is a per-run concern, so a workflow run
+        accepts the same values a freeform run does. Request-body values win
+        over the template server-side, except `tools`, which is merged.
+        """
+        fields: Dict[str, Any] = {}
+
+        if tools is not None:
+            fields["tools"] = (
+                tools if isinstance(tools, dict) else tools.model_dump(exclude_none=True)
+            )
+        elif code_execution is not None:
+            # Backward compatibility: top-level code_execution (deprecated)
+            fields["code_execution"] = code_execution
+
+        if search:
+            fields["search"] = (
+                search.model_dump(exclude_none=True)
+                if isinstance(search, SearchConfig)
+                else search
+            )
+        if urls:
+            fields["urls"] = urls
+        if files:
+            fields["files"] = [
+                (
+                    f.model_dump(by_alias=True, exclude_none=True)
+                    if isinstance(f, FileAttachment)
+                    else f
+                )
+                for f in files
+            ]
+        if deliverables:
+            fields["deliverables"] = [
+                d.model_dump(exclude_none=True) if isinstance(d, Deliverable) else d
+                for d in deliverables
+            ]
+        if mcp_servers:
+            fields["mcp_servers"] = [
+                s.model_dump(exclude_none=True) if isinstance(s, MCPServerConfig) else s
+                for s in mcp_servers
+            ]
+        if previous_reports:
+            fields["previous_reports"] = previous_reports
+        if webhook_url:
+            fields["webhook_url"] = webhook_url
+        if alert_email is not None:
+            if isinstance(alert_email, AlertEmailConfig):
+                fields["alert_email"] = alert_email.model_dump(exclude_none=True)
+            else:
+                fields["alert_email"] = alert_email
+        if brand_collection_id:
+            fields["brand_collection_id"] = brand_collection_id
+        if metadata:
+            fields["metadata"] = metadata
+        if hitl is not None:
+            fields["hitl"] = (
+                hitl.model_dump(exclude_none=True)
+                if isinstance(hitl, HitlConfig)
+                else hitl
+            )
+
+        return fields
 
     def create(
         self,
@@ -144,7 +228,13 @@ class DeepResearchClient:
                         The workflow's template supplies the prompt, strategy,
                         report format, deliverables, and mode. Mutually exclusive
                         with query/input/research_strategy/report_format.
-            workflow_params: Values for the workflow's variables
+                        Every other parameter on this method still applies to a
+                        workflow run, and a value passed here overrides the
+                        template's — except tools, which is merged with it.
+            workflow_params: Values for the workflow's variables. Keys must match
+                        the workflow's declared variables; read them from
+                        client.workflows.get(slug).workflow.variables, since they
+                        differ per workflow.
             workflow_version: Specific workflow version to run (defaults to current)
 
         Returns:
@@ -180,6 +270,19 @@ class DeepResearchClient:
                         success=False,
                         error="workflow_id is mutually exclusive with query/input/research_strategy/report_format - the workflow template supplies those fields",
                     )
+                if files:
+                    for i, f in enumerate(files):
+                        ctx = (
+                            f.context
+                            if isinstance(f, FileAttachment)
+                            else (f.get("context") if isinstance(f, dict) else None)
+                        )
+                        if ctx and len(ctx) > 10000:
+                            return DeepResearchCreateResponse(
+                                success=False,
+                                error=f"files[{i}].context exceeds 10,000 character limit ({len(ctx)} characters)",
+                            )
+
                 payload: Dict[str, Any] = {"workflow_id": workflow_id}
                 if workflow_params is not None:
                     payload["workflow_params"] = workflow_params
@@ -194,24 +297,26 @@ class DeepResearchClient:
                     )
                 if output_formats:
                     payload["output_formats"] = output_formats
-                if webhook_url:
-                    payload["webhook_url"] = webhook_url
-                if alert_email is not None:
-                    if isinstance(alert_email, str):
-                        payload["alert_email"] = alert_email
-                    elif isinstance(alert_email, AlertEmailConfig):
-                        payload["alert_email"] = alert_email.model_dump(
-                            exclude_none=True
-                        )
-                    else:
-                        payload["alert_email"] = alert_email
-                if metadata:
-                    payload["metadata"] = metadata
-                if tools is not None:
-                    if isinstance(tools, dict):
-                        payload["tools"] = tools
-                    else:
-                        payload["tools"] = tools.model_dump(exclude_none=True)
+
+                # Per-run options are as valid on a workflow run as on a
+                # freeform one — the template only supplies the freeform fields.
+                payload.update(
+                    self._build_shared_fields(
+                        search=search,
+                        urls=urls,
+                        files=files,
+                        deliverables=deliverables,
+                        mcp_servers=mcp_servers,
+                        previous_reports=previous_reports,
+                        webhook_url=webhook_url,
+                        alert_email=alert_email,
+                        brand_collection_id=brand_collection_id,
+                        metadata=metadata,
+                        hitl=hitl,
+                        tools=tools,
+                        code_execution=code_execution,
+                    )
+                )
 
                 response = self._session.post(
                     f"{self._base_url}/deepresearch/tasks",
@@ -222,10 +327,7 @@ class DeepResearchClient:
                 if not response.ok:
                     return DeepResearchCreateResponse(
                         success=False,
-                        error=data.get(
-                            "message",
-                            data.get("error", f"HTTP Error: {response.status_code}"),
-                        ),
+                        error=_error_message(data, response.status_code),
                     )
 
                 data.pop("success", None)
@@ -271,15 +373,6 @@ class DeepResearchClient:
                 "output_formats": output_formats or ["markdown"],
             }
 
-            # Handle tools configuration
-            if tools is not None:
-                if isinstance(tools, dict):
-                    payload["tools"] = tools
-                else:
-                    payload["tools"] = tools.model_dump(exclude_none=True)
-            elif code_execution is not None:
-                # Backward compatibility: top-level code_execution (deprecated)
-                payload["code_execution"] = code_execution
             # Also send input if it was provided (for backward compatibility with older API versions)
             if input:
                 payload["input"] = input
@@ -287,61 +380,31 @@ class DeepResearchClient:
             if model is not None:
                 payload["model"] = model if model != "lite" else "standard"
 
-            # Add optional fields
+            # Freeform-only fields — a workflow template supplies these instead
             if strategy:
                 payload["strategy"] = strategy
             if research_strategy:
                 payload["research_strategy"] = research_strategy
             if report_format:
                 payload["report_format"] = report_format
-            if search:
-                if isinstance(search, SearchConfig):
-                    search_dict = search.model_dump(exclude_none=True)
-                else:
-                    search_dict = search
-                payload["search"] = search_dict
-            if urls:
-                payload["urls"] = urls
-            if files:
-                payload["files"] = [
-                    (
-                        f.model_dump(by_alias=True, exclude_none=True)
-                        if isinstance(f, FileAttachment)
-                        else f
-                    )
-                    for f in files
-                ]
-            if deliverables:
-                payload["deliverables"] = [
-                    d.model_dump(exclude_none=True) if isinstance(d, Deliverable) else d
-                    for d in deliverables
-                ]
-            if mcp_servers:
-                payload["mcp_servers"] = [
-                    s.model_dump(exclude_none=True) if isinstance(s, MCPServerConfig) else s
-                    for s in mcp_servers
-                ]
-            if previous_reports:
-                payload["previous_reports"] = previous_reports
-            if webhook_url:
-                payload["webhook_url"] = webhook_url
-            if alert_email is not None:
-                if isinstance(alert_email, str):
-                    payload["alert_email"] = alert_email
-                elif isinstance(alert_email, AlertEmailConfig):
-                    payload["alert_email"] = alert_email.model_dump(exclude_none=True)
-                else:
-                    payload["alert_email"] = alert_email
-            if brand_collection_id:
-                payload["brand_collection_id"] = brand_collection_id
-            if metadata:
-                payload["metadata"] = metadata
 
-            if hitl is not None:
-                if isinstance(hitl, HitlConfig):
-                    payload["hitl"] = hitl.model_dump(exclude_none=True)
-                else:
-                    payload["hitl"] = hitl
+            payload.update(
+                self._build_shared_fields(
+                    search=search,
+                    urls=urls,
+                    files=files,
+                    deliverables=deliverables,
+                    mcp_servers=mcp_servers,
+                    previous_reports=previous_reports,
+                    webhook_url=webhook_url,
+                    alert_email=alert_email,
+                    brand_collection_id=brand_collection_id,
+                    metadata=metadata,
+                    hitl=hitl,
+                    tools=tools,
+                    code_execution=code_execution,
+                )
+            )
 
             response = self._session.post(
                 f"{self._base_url}/deepresearch/tasks",
@@ -353,7 +416,7 @@ class DeepResearchClient:
             if not response.ok:
                 return DeepResearchCreateResponse(
                     success=False,
-                    error=data.get("error", f"HTTP Error: {response.status_code}"),
+                    error=_error_message(data, response.status_code),
                 )
 
             data.pop("success", None)

--- a/valyu/workflows_client.py
+++ b/valyu/workflows_client.py
@@ -7,6 +7,7 @@ Run one by passing workflow_id (the slug) to deepresearch.create().
 """
 
 from typing import Optional, List, Dict, Any, Literal
+from valyu._errors import error_message
 from valyu.types.workflows import (
     Workflow,
     WorkflowDeleteResponse,
@@ -29,9 +30,7 @@ class WorkflowsClient:
 
     @staticmethod
     def _error_message(data: Dict[str, Any], status_code: int) -> str:
-        return (
-            data.get("message") or data.get("error") or f"HTTP Error: {status_code}"
-        )
+        return error_message(data, status_code)
 
     def list(
         self,


### PR DESCRIPTION
## Summary

Running a workflow through `deepresearch.create()` silently discarded most of the options passed alongside it. The workflow branch built its own, much smaller payload, so these never reached the wire:

`deliverables`, `search`, `previous_reports`, `hitl`, `urls`, `files`, `mcp_servers`, `brand_collection_id`, `code_execution`

The API accepts all of them on a workflow run and lets a request-body value override the template, so passing them was a no-op rather than an error — the run just quietly used the template defaults.

## What changed

**Per-run options now reach the wire on workflow runs.** Both code paths build the shared fields through one helper, so their serialisation is identical by construction rather than by two lists staying in sync.

The workflow branch keeps its own handling of the genuinely template-supplied fields:
- `mode` and `output_formats` are still only sent when explicitly set, so a workflow's recommended defaults apply otherwise
- `query` / `strategy` / `report_format` remain mutually exclusive with `workflow_id`
- the `files[].context` length guard now applies to workflow runs too

**Validation errors now name the offending field.** The API returns an `errors` array identifying each problem; only the summary was kept. A wrong `workflow_params` key used to produce:

```
2 validation errors
```

and now produces:

```
2 validation errors: Unknown parameter "company"; Required parameter "target" is missing
```

That matters because workflows declare different variable names — `ib-company-profile` takes `company`, `ib-comps-analysis` takes `target`, `ib-precedent-transactions` takes `sector` — so a caller guessing the wrong key previously had nothing to go on.

**Version single-sourced.** `setup.py` now reads the version from `valyu/__init__.py` instead of repeating it. The two had drifted (`setup.py` 2.11.1, `__version__` 2.10.0), and since `__version__` is sent as `User-Agent` and `X-Valyu-SDK-Version` on every request, a stale constant misreports which build a request came from. Bumped to 2.12.0.

## Verification

17 tests pass, including new coverage that the two code paths serialise per-run options identically, that a bare workflow run stays minimal so template defaults still apply, and that the mutual-exclusion and `files[].context` guards still fire.

Checked against the live API — a workflow run now honours a `deliverables` override instead of falling back to the template's, and the validation message above is the real response.

## Compatibility

No signature changes and no behaviour change for freeform runs. Workflow runs that already passed these options will start having them applied, which is the documented behaviour; a run that relied on them being ignored would need them removed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/valyuAI/codesmith/valyu-py/pr/128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787834297&installation_model_id=424733&pr_number=128&repository=valyuAI%2Fvalyu-py&return_to=https%3A%2F%2Fgithub.com%2FvalyuAI%2Fvalyu-py%2Fpull%2F128&signature=3205fde28e57484324cab29b835517de21401b0d80e5a1bef53584b29cf10683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
