### PR TITLE
Add PubMed abstract search option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ response = valyu.search(
     search_type="proprietary",                     # "all", "web", or "proprietary"
     max_num_results=10,                            # 1-20 results
     included_sources=["valyu/valyu-pubmed"],        # filter to specific sources
+    include_abstracts=True,                         # search the full PubMed abstract corpus
     start_date="2026-01-01",                       # date filtering
     end_date="2026-12-31",
 )
@@ -65,6 +66,7 @@ response = valyu.search(
 | `end_date` | `str` | `None` | End date (YYYY-MM-DD) |
 | `country_code` | `str` | `None` | Country filter (e.g. `"US"`, `"GB"`) |
 | `response_length` | `str \| int` | `None` | `"short"`, `"medium"`, `"large"`, `"max"`, or character count |
+| `include_abstracts` | `bool` | `False` | Search PubMed's complete abstract corpus instead of full-text papers |
 | `category` | `str` | `None` | Category filter |
 | `fast_mode` | `bool` | `False` | Faster results, shorter content |
 

--- a/tests/test_search_include_abstracts.py
+++ b/tests/test_search_include_abstracts.py
@@ -1,0 +1,60 @@
+import unittest
+from unittest.mock import MagicMock
+
+from valyu import Valyu
+from valyu._request_builders import build_search_payload
+
+
+def _search_response():
+    response = MagicMock()
+    response.ok = True
+    response.status_code = 200
+    response.json.return_value = {
+        "success": True,
+        "error": None,
+        "tx_id": "tx_test",
+        "query": "cancer immunotherapy",
+        "results": [],
+        "results_by_source": {"web": 0, "proprietary": 0},
+        "total_deduction_dollars": 0.0,
+        "total_characters": 0,
+    }
+    return response
+
+
+class IncludeAbstractsTest(unittest.TestCase):
+    def test_sync_search_forwards_include_abstracts(self):
+        client = Valyu(api_key="val_test")
+        client._session.post = MagicMock(return_value=_search_response())
+
+        client.search("cancer immunotherapy", include_abstracts=True)
+
+        payload = client._session.post.call_args.kwargs["json"]
+        self.assertIs(payload["include_abstracts"], True)
+
+    def test_async_payload_builder_defaults_include_abstracts_to_false(self):
+        payload = build_search_payload(
+            query="cancer immunotherapy",
+            search_type="proprietary",
+            max_num_results=10,
+            is_tool_call=True,
+            relevance_threshold=0.5,
+            max_price=None,
+            included_sources=["valyu/valyu-pubmed"],
+            excluded_sources=None,
+            country_code=None,
+            response_length=None,
+            category=None,
+            start_date=None,
+            end_date=None,
+            fast_mode=False,
+            url_only=False,
+            source_biases=None,
+            instructions=None,
+        )
+
+        self.assertIs(payload["include_abstracts"], False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/valyu/__init__.py
+++ b/valyu/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.12.0"
+__version__ = "2.12.1"
 
 from .types.response import SearchResponse
 from .types.contents import (

--- a/valyu/_request_builders.py
+++ b/valyu/_request_builders.py
@@ -70,6 +70,7 @@ def build_search_payload(
     source_biases: Optional[Dict[str, int]],
     instructions: Optional[str],
     historical_cache: Optional[bool] = None,
+    include_abstracts: bool = False,
 ) -> Dict[str, Any]:
     payload: Dict[str, Any] = {
         "query": query,
@@ -79,6 +80,7 @@ def build_search_payload(
         "relevance_threshold": relevance_threshold,
         "fast_mode": fast_mode,
         "url_only": url_only,
+        "include_abstracts": include_abstracts,
     }
     if max_price is not None:
         payload["max_price"] = max_price

--- a/valyu/api.py
+++ b/valyu/api.py
@@ -154,6 +154,7 @@ class Valyu:
         source_biases: Optional[Dict[str, int]] = None,
         instructions: Optional[str] = None,
         historical_cache: Optional[bool] = None,
+        include_abstracts: bool = False,
     ) -> Optional[SearchResponse]:
         """
         Query the Valyu DeepSearch API to give your AI relevant context.
@@ -193,6 +194,9 @@ class Valyu:
             historical_cache (Optional[bool]): When True and a date range (start_date and/or
                 end_date) is set, return the newest cached snapshot inside the range instead
                 of the latest crawl. No-op without a date range. Defaults to False.
+            include_abstracts (bool): Search PubMed's complete abstract corpus and return
+                document-level abstracts. When False, PubMed search returns full-text papers.
+                Defaults to False.
 
         Returns:
             Optional[SearchResponse]: The search response.
@@ -252,6 +256,7 @@ class Valyu:
                 "relevance_threshold": relevance_threshold,
                 "fast_mode": fast_mode,
                 "url_only": url_only,
+                "include_abstracts": include_abstracts,
             }
 
             if max_price is not None:

--- a/valyu/async_api.py
+++ b/valyu/async_api.py
@@ -188,6 +188,7 @@ class AsyncValyu:
         source_biases: Optional[Dict[str, int]] = None,
         instructions: Optional[str] = None,
         historical_cache: Optional[bool] = None,
+        include_abstracts: bool = False,
     ) -> Optional[SearchResponse]:
         """
         Async version of ``Valyu.search``. See :py:meth:`Valyu.search`
@@ -223,6 +224,7 @@ class AsyncValyu:
                 source_biases=source_biases,
                 instructions=instructions,
                 historical_cache=historical_cache,
+                include_abstracts=include_abstracts,
             )
 
             response = await self._post("/search", payload)


### PR DESCRIPTION
## Summary
- add `include_abstracts` to synchronous and asynchronous search
- expose the option in request payloads with a backwards-compatible default
- bump the package version to 2.12.1 and document usage

## Testing
- `python3 -m pytest tests -v`
- `python3 -m build`
- production PubMed smoke test with an abstract response

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/valyuAI/codesmith/valyu-py/pr/129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789107428&installation_model_id=424733&pr_number=129&repository=valyuAI%2Fvalyu-py&return_to=https%3A%2F%2Fgithub.com%2FvalyuAI%2Fvalyu-py%2Fpull%2F129&signature=bf49db6889f3b97fd95d2863af8da5a56c4455993d08727d3194304eadebc7f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->